### PR TITLE
Update 'register your interest' content on 4 pages 

### DIFF
--- a/src/views/find-out-more.njk
+++ b/src/views/find-out-more.njk
@@ -94,26 +94,38 @@
         <h2 class="govuk-heading-m">What registering your interest means</h2>
 
         <p class="govuk-body">
-          We want to find some services to join us in our private beta.
-          We plan to connect these services in late 2021.
+          Once you tell us you’re interested in GOV.UK Sign In, there are 3 things you’ll be able to do.
+        </p>
+        
+        <h3 class="govuk-heading-s">Stay up to date with our progress</h3>
+
+        <p class="govuk-body">
+          You can get more information on our work by joining our mailing list and coming to our cross-government show and tells.
+        </p>
+        
+        <h3 class="govuk-heading-s">Have a say in how GOV.UK Sign In develops</h3>
+
+        <p class="govuk-body">
+          We arrange a phone call with every team that tells us they’re interested. We’ll ask you more about your service and what you need from an authentication or identity checking product.
         </p>
 
         <p class="govuk-body">
-          We will get in touch to find out more about your service.
-          Our private beta partner services will be the ones we can learn the most from.
-        </p>
-
-        <p class="govuk-body">
-          We want everyone that registers their interest to have a say in how GOV.UK Sign In develops.
-        </p>
-
-        <p class="govuk-body">
-          When you register your interest you can:
+          This phone call will help us understand things like: 
         <ul class="govuk-list govuk-list--bullet">
-          <li>sign up for our cross-government show and tells</li>
-          <li>agree to help us with our user research</li>
-          <li>sign up for updates on our progress</li>
+          <li>how your service works</li>
+          <li>what sort of things you need to check about your users</li>
+          <li>how those checks fit into your user journey</li>
         </ul>
+        </p>
+        
+        <p class="govuk-body">
+          We’ll also invite you to take part in user research sessions. We’ll show you prototypes and ideas we’ve been working on and make sure we’re building things that meet your needs.
+        </p>
+        
+        <h3 class="govuk-heading-s">Potentially join private beta</h3>
+        
+        <p class="govuk-body">
+          We need to work with some services in private beta from late 2021. We’ll choose the services we can learn the most from.
         </p>
 
         <p class="govuk-body">

--- a/src/views/getting-started.njk
+++ b/src/views/getting-started.njk
@@ -52,15 +52,25 @@
 
         <p class="govuk-body">
           <a class="govuk-link" href="/register">Register your interest</a> by giving us some information about your
-          organisation and your service. It will take 10 minutes to complete this form.
+          organisation and your service. 
         </p>
 
-        <p class="govuk-body">
-          We will contact you to find out more about your service.
-          We plan to start connecting our beta partner services in late 2021.
-        </p>
-      </div>
-    </div>
+        <p class="govuk-body">Once you've done this, you'll be able to:</p>
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>
+            speak to us about your service’s identity checking needs
+          </li>
+          <li>
+            take part in our user research
+          </li>
+          <li>
+            get updates about our work
+          </li>
+          <li>
+            potentially join our group of private beta partners 
+          </li>
+        </ul>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/src/views/identity-checks.njk
+++ b/src/views/identity-checks.njk
@@ -64,25 +64,22 @@
 
         <h2 class="govuk-heading-m">Help us design the identity checks</h2>
 
-        <p class="govuk-body">Register your interest if you’re interested in being our private beta partner. It’ll only take 10 minutes.</p>
-
-        <p class="govuk-body">Once you’ve registered, we’ll:</p>
+        <p class="govuk-body"><a class="govuk-link" href="https://www.sign-in.service.gov.uk/register">Register your interest</a> to:</p>
 
         <ul class="govuk-list govuk-list--bullet">
           <li>
-            arrange a call with you to find out more about your service
+            tell us about your service’s identity checking needs
           </li>
           <li>
-            contact you to help us with our user research
+            take part in our user research
           </li>
           <li>
-            add your service to our pool of potential beta partners
+            get updates about our work
+          </li>
+          <li>
+            potentially join our group of private beta partners 
           </li>
         </ul>
-
-        <p class="govuk-body">We can also answer any questions you have for us.</p>
-
-        <p class="govuk-body"><a class="govuk-link" href="https://www.sign-in.service.gov.uk/register">Register your interest</a> in identity.</p>
 
       </div>
     </div>

--- a/src/views/register-confirm.njk
+++ b/src/views/register-confirm.njk
@@ -42,23 +42,14 @@
         <h2 class="govuk-heading-m">What next</h2>
 
         <p class="govuk-body">
-          We will get in touch to find out more about your service.
-          We plan to start connecting our chosen beta partner services in late 2021.
-        </p>
-
-        <p class="govuk-body">
-          We’ll update you on our progress:
-        <ul class="govuk-list govuk-list--bullet">
-          <li>in our cross-government show and tells</li>
-          <li>on our <a href="/">product page</a></li>
-        </ul>
+          We’ll get in touch within 5 working days to find out more about your service.
         </p>
 
         <p class="govuk-body">
           In the meantime, ask us any questions at
           <a class="govuk-link" href="mailto:govuk-sign-in@digital.cabinet-office.gov.uk">
             govuk-sign-in@digital.cabinet-office.gov.uk
-          </a>.
+          </a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
## What 

Update the places where we refer to 'registering your interest' to set clearer expectations about what will actually happen if you do it. 

## Why 

Some service teams were expecting quite different things from our register interest/first contact process, so we needed to clear it up. In particular, we needed to make it less about joining beta, and more about speaking to us and staying up to date.