### PR TITLE
DFA-304: Set secret env vars correctly

### DIFF
--- a/.github/workflows/deploy-to-paas.yml
+++ b/.github/workflows/deploy-to-paas.yml
@@ -50,5 +50,5 @@ jobs:
       - name: Push to PaaS
         run: |
           cd deploy
-          cf push --var "REGISTER_SPREADSHEET_ID=${{ secrets.REGISTER_SPREADSHEET_ID }}" \
-                  --var "REQUEST_SPREADSHEET_ID=${{ secrets.REQUEST_SPREADSHEET_ID }}"
+          cf push --var "register_spreadsheet_id=${{ secrets.REGISTER_SPREADSHEET_ID }}" \
+                  --var "request_spreadsheet_id=${{ secrets.REQUEST_SPREADSHEET_ID }}"

--- a/manifest.yml
+++ b/manifest.yml
@@ -10,3 +10,5 @@ applications:
       REGISTER_SHEET_HEADER_RANGE: Register!A1:Y1
       REQUEST_SHEET_DATA_RANGE: "'Request to join private beta '!A1"
       REQUEST_SHEET_HEADER_RANGE: "'Request to join private beta '!A1:F1"
+      REGISTER_SPREADSHEET_ID: ((register_spreadsheet_id))
+      REQUEST_SPREADSHEET_ID: ((request_spreadsheet_id))


### PR DESCRIPTION
The `--var` flag sets values for variable substitution in the manifest file. The vars from GitHub need to be piped through to the deployment environment.