### PR TITLE
DFA-28 The mystery of the missing text

### DIFF
--- a/src/views/contact-us.njk
+++ b/src/views/contact-us.njk
@@ -173,14 +173,14 @@
               </span>
                             {% endif %}
                             <textarea class="govuk-textarea" id="how-can-we-help" name="how-can-we-help" rows="5"
-                                      aria-describedby="how-can-we-help-error"></textarea>
+                                      aria-describedby="how-can-we-help-error">{{ values.get('how-can-we-help') }}</textarea>
                         </div>
 
                     </fieldset>
 
 
                     <button class="govuk-button" data-module="govuk-button">
-                        Submit
+                        Submit form
                     </button>
 
                 </form>


### PR DESCRIPTION
If the validation fails, the value of the how-can-we-help textarea is not rendered in the template.  The text for the submit button was is also wrong.

Render value of how-can-we-help textarea when validation fails.

Alter text of submit button.