### PR TITLE
DFA-45 Add empty values for vars

### DIFF
--- a/.github/workflows/deploy-to-paas.yml
+++ b/.github/workflows/deploy-to-paas.yml
@@ -54,3 +54,5 @@ jobs:
                   --var "request_spreadsheet_id=${{ secrets.REQUEST_SPREADSHEET_ID }}" \
                   --var "use_stub_zendesk=${{ secrets.USE_STUB_ZENDESK }}" \
                   --var "zendesk_api_token=${{ secrets.ZENDESK_API_TOKEN }}"
+                  --var "zendesk_group_id=''"
+                  --var "zendesk_username=''"


### PR DESCRIPTION
TIL PaaS will need values for things you put in the manifest.  Which should have been obvious to me really.