### PR TITLE
DFA-376: Deploy a preview app for each pull request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Build
+
+on: workflow_call
+
+jobs:
+  build:
+    name: Build pages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull repository
+        uses: actions/checkout@v2
+
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          cache: 'npm'
+
+      - name: Install Node dependencies
+        run: npm install
+
+      - name: Build app
+        run: npm run build
+
+      - name: Archive distribution artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: product-pages
+          retention-days: 7
+          path: |
+            dist
+            src/views
+            package*.json
+            manifest.yml
+            valid-email-domains.txt

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,25 +1,31 @@
-name: Deploy to PaaS
+name: Deploy
 
 on:
-  push:
-    branches: [ main ]
+  workflow_call:
+    inputs:
+      environment: { required: true, type: string }
+      url: { required: false, type: string }
+      app_name: { required: false, type: string }
+      use_stub_zendesk: { required: true, type: boolean }
+    secrets:
+      CF_USERNAME: { required: true }
+      CF_PASSWORD: { required: true }
+      ZENDESK_API_TOKEN: { required: true }
+      REGISTER_SPREADSHEET_ID: { required: true }
+      REQUEST_SPREADSHEET_ID: { required: true }
 
 jobs:
-  deploy-test:
-    name: Deploy / Test
+  deploy:
+    name: Deploy to PaaS
     runs-on: ubuntu-latest
-    environment: test
+    environment:
+      name: ${{ inputs.environment }}
+      url: ${{ inputs.url }}
     steps:
-      - name: Pull repository
-        uses: actions/checkout@v2
-
-      - name: Install Node
-        uses: actions/setup-node@v2
+      - name: Get distribution artifact
+        uses: actions/download-artifact@v2
         with:
-          cache: 'npm'
-
-      - name: Install Node dependencies
-        run: npm install
+          name: product-pages
 
       - name: Install Cloud Foundry client
         env:
@@ -28,21 +34,11 @@ jobs:
           curl -sL ${CF_CLI_DOWNLOAD_URL} | sudo tar -zx -C /usr/local/bin
           cf version
 
-      - name: Build app
-        run: npm run build
-
-      - name: Prepare deployment directory
-        run: |
-          mkdir deploy && mkdir deploy/src/
-          cp -r dist/ deploy/dist/
-          cp -r src/views/ deploy/src/views
-          cp package*.json manifest.yml valid-email-domains.txt deploy/
-
       - name: PaaS login
         env:
           CF_API_URL: https://api.london.cloud.service.gov.uk
           CF_ORG_NAME: gds-digital-identity-onboarding
-          CF_SPACE_NAME: product-pages-test
+          CF_SPACE_NAME: product-pages-preview
           CF_USERNAME: ${{ secrets.CF_USERNAME }}
           CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
         run: |
@@ -52,10 +48,10 @@ jobs:
 
       - name: Push to PaaS
         run: |
-          cd deploy
-          cf push --var "register_spreadsheet_id=${{ secrets.REGISTER_SPREADSHEET_ID }}" \
+          cf push ${{ inputs.app_name }} \
+                  --var "register_spreadsheet_id=${{ secrets.REGISTER_SPREADSHEET_ID }}" \
                   --var "request_spreadsheet_id=${{ secrets.REQUEST_SPREADSHEET_ID }}" \
-                  --var "use_stub_zendesk=${{ secrets.USE_STUB_ZENDESK }}" \
+                  --var "use_stub_zendesk=${{ inputs.USE_STUB_ZENDESK }}" \
                   --var "zendesk_api_token=${{ secrets.ZENDESK_API_TOKEN }}" \
                   --var "zendesk_group_id=''" \
                   --var "zendesk_username=''"

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -1,0 +1,47 @@
+name: Test PR
+
+on: pull_request
+
+jobs:
+  build:
+    name: Build
+    uses: alphagov/di-onboarding-product-page/.github/workflows/build.yml@f750c28d35c2dce51c78ad36b6e112e8cf0ec62b
+
+  unit-test:
+    name: Run unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull repository
+        uses: actions/checkout@v2
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          cache: 'npm'
+      - name: Install Node dependencies
+        run: npm install
+
+      - name: Run mocha tests
+        run: npm run test
+
+  deploy-preview:
+    name: Preview
+    needs: build
+    uses: alphagov/di-onboarding-product-page/.github/workflows/deploy.yml@f750c28d35c2dce51c78ad36b6e112e8cf0ec62b
+    with:
+      environment: preview
+      app_name: di-product-page-preview-${{ github.head_ref }}
+      url: https://di-product-page-preview-${{ github.head_ref }}.london.cloudapps.digital
+      use_stub_zendesk: true
+    secrets:
+      CF_USERNAME: ${{ secrets.CF_USERNAME }}
+      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
+      ZENDESK_API_TOKEN: ${{ secrets.ZENDESK_API_TOKEN }}
+      REGISTER_SPREADSHEET_ID: ${{ secrets.REGISTER_SPREADSHEET_ID }}
+      REQUEST_SPREADSHEET_ID: ${{ secrets.REQUEST_SPREADSHEET_ID }}
+
+  run-acceptance-tests:
+    name: Run acceptance tests
+    runs-on: ubuntu-latest
+    needs: deploy-preview
+    steps:
+      - run: echo "Ask John"

--- a/.gitignore
+++ b/.gitignore
@@ -72,8 +72,9 @@ typings/
 .env
 .env.test
 
-# Google service account credentials
+# Credentials
 googleCredentials.json
+zendeskCredentials.txt
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache
@@ -128,4 +129,3 @@ keys/
 .vscode/
 
 ci/terraform/.terraform
-/zendeskCredentials.txt

--- a/manifest.yml
+++ b/manifest.yml
@@ -3,6 +3,8 @@ applications:
   - name: onboarding-product-pages
     memory: 512M
     disk_quota: 512M
+    services:
+      - google-service-account
     env:
       USE_STUB_S3: true
       USE_STUB_SHEETS: false

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "buildgovuk": "cp -v -r node_modules/govuk-frontend/govuk/assets/* ./dist/assets && echo \"Done!\"",
     "buildlocalimages": "cp -v -r assets/images/* ./dist/assets/images",
     "build": "npm run buildts && npm run buildsass && npm run buildjs && npm run buildgovuk && npm run buildlocalimages",
-    "test": "mocha"
+    "test": "mocha --require ts-node/register --ui bdd src/**/*.spec.ts"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
Add a "Test PR" workflow that deploys a preview app each time a pull request is opened or updated.
The workflow uses reusable workflows which will be later used in the production pipeline as well.
The preview pipeline builds the app, runs unit tests, deploys to PaaS and runs acceptance tests (stub job for now).
Each app is deployed on a unique URL derived from the branch name.

  - Cache npm modules
  - Run unit tests using mocha