### PR TITLE
DFA-376 & DFA-377: Workflow housekeeping & production pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: workflow_call
 
 jobs:
   build:
-    name: Build pages
+    name: Product pages
     runs-on: ubuntu-latest
     steps:
       - name: Pull repository

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -5,16 +5,16 @@ on: pull_request
 jobs:
   build:
     name: Build
-    uses: alphagov/di-onboarding-product-page/.github/workflows/build.yml@f750c28d35c2dce51c78ad36b6e112e8cf0ec62b
+    uses: alphagov/di-onboarding-product-page/.github/workflows/build.yml@0fc71869649811ea52287bc833949a78730c653e
 
   run-unit-tests:
     name: Run tests
-    uses: alphagov/di-onboarding-product-page/.github/workflows/run-unit-tests.yml@f750c28d35c2dce51c78ad36b6e112e8cf0ec62b
+    uses: alphagov/di-onboarding-product-page/.github/workflows/run-unit-tests.yml@0fc71869649811ea52287bc833949a78730c653e
 
   deploy-preview:
     name: Preview
     needs: build
-    uses: alphagov/di-onboarding-product-page/.github/workflows/deploy-to-paas.yml@f750c28d35c2dce51c78ad36b6e112e8cf0ec62b
+    uses: alphagov/di-onboarding-product-page/.github/workflows/deploy-to-paas.yml@0fc71869649811ea52287bc833949a78730c653e
     with:
       environment: preview
       cf_space_name: product-pages-preview
@@ -30,4 +30,4 @@ jobs:
   run-acceptance-tests:
     name: Run tests
     needs: deploy-preview
-    uses: alphagov/di-onboarding-product-page/.github/workflows/run-acceptance-tests.yml@f750c28d35c2dce51c78ad36b6e112e8cf0ec62b
+    uses: alphagov/di-onboarding-product-page/.github/workflows/run-acceptance-tests.yml@0fc71869649811ea52287bc833949a78730c653e

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,4 +1,4 @@
-name: Test PR
+name: Check PR
 
 on: pull_request
 
@@ -14,7 +14,7 @@ jobs:
   deploy-preview:
     name: Preview
     needs: build
-    uses: alphagov/di-onboarding-product-page/.github/workflows/deploy.yml@f750c28d35c2dce51c78ad36b6e112e8cf0ec62b
+    uses: alphagov/di-onboarding-product-page/.github/workflows/deploy-to-paas.yml@f750c28d35c2dce51c78ad36b6e112e8cf0ec62b
     with:
       environment: preview
       app_name: di-product-page-preview-${{ github.head_ref }}

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -17,14 +17,15 @@ jobs:
     uses: alphagov/di-onboarding-product-page/.github/workflows/deploy-to-paas.yml@f750c28d35c2dce51c78ad36b6e112e8cf0ec62b
     with:
       environment: preview
+      cf_space_name: product-pages-preview
       app_name: di-product-page-preview-${{ github.head_ref }}
       url: https://di-product-page-preview-${{ github.head_ref }}.london.cloudapps.digital
       use_stub_zendesk: true
     secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      REGISTER_SPREADSHEET_ID: ${{ secrets.REGISTER_SPREADSHEET_ID }}
-      REQUEST_SPREADSHEET_ID: ${{ secrets.REQUEST_SPREADSHEET_ID }}
+      cf_username: ${{ secrets.CF_USERNAME }}
+      cf_password: ${{ secrets.CF_PASSWORD }}
+      register_spreadsheet_id: ${{ secrets.REGISTER_SPREADSHEET_ID }}
+      request_spreadsheet_id: ${{ secrets.REQUEST_SPREADSHEET_ID }}
 
   run-acceptance-tests:
     name: Run tests

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -7,21 +7,9 @@ jobs:
     name: Build
     uses: alphagov/di-onboarding-product-page/.github/workflows/build.yml@f750c28d35c2dce51c78ad36b6e112e8cf0ec62b
 
-  unit-test:
-    name: Run unit tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Pull repository
-        uses: actions/checkout@v2
-      - name: Install Node
-        uses: actions/setup-node@v2
-        with:
-          cache: 'npm'
-      - name: Install Node dependencies
-        run: npm install
-
-      - name: Run mocha tests
-        run: npm run test
+  run-unit-tests:
+    name: Run tests
+    uses: alphagov/di-onboarding-product-page/.github/workflows/run-unit-tests.yml@f750c28d35c2dce51c78ad36b6e112e8cf0ec62b
 
   deploy-preview:
     name: Preview
@@ -39,8 +27,6 @@ jobs:
       REQUEST_SPREADSHEET_ID: ${{ secrets.REQUEST_SPREADSHEET_ID }}
 
   run-acceptance-tests:
-    name: Run acceptance tests
-    runs-on: ubuntu-latest
+    name: Run tests
     needs: deploy-preview
-    steps:
-      - run: echo "Ask John"
+    uses: alphagov/di-onboarding-product-page/.github/workflows/run-acceptance-tests.yml@f750c28d35c2dce51c78ad36b6e112e8cf0ec62b

--- a/.github/workflows/deploy-to-paas.yml
+++ b/.github/workflows/deploy-to-paas.yml
@@ -4,17 +4,18 @@ on:
   workflow_call:
     inputs:
       environment: { required: true, type: string }
-      url: { required: false, type: string }
-      app_name: { required: false, type: string }
+      cf_space_name: { required: true, type: string }
       use_stub_zendesk: { required: true, type: boolean }
+      app_name: { required: false, type: string }
+      url: { required: false, type: string }
     secrets:
-      CF_USERNAME: { required: true }
-      CF_PASSWORD: { required: true }
-      REGISTER_SPREADSHEET_ID: { required: true }
-      REQUEST_SPREADSHEET_ID: { required: true }
-      ZENDESK_API_TOKEN: { required: false }
-      ZENDESK_GROUP_ID: { required: false }
-      ZENDESK_USERNAME: { required: false }
+      cf_username: { required: true }
+      cf_password: { required: true }
+      register_spreadsheet_id: { required: true }
+      request_spreadsheet_id: { required: true }
+      zendesk_api_token: { required: false }
+      zendesk_group_id: { required: false }
+      zendesk_username: { required: false }
 
 jobs:
   deploy:
@@ -40,9 +41,9 @@ jobs:
         env:
           CF_API_URL: https://api.london.cloud.service.gov.uk
           CF_ORG_NAME: gds-digital-identity-onboarding
-          CF_SPACE_NAME: product-pages-preview
-          CF_USERNAME: ${{ secrets.CF_USERNAME }}
-          CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
+          CF_SPACE_NAME: ${{ inputs.cf_space_name }}
+          CF_USERNAME: ${{ secrets.cf_username }}
+          CF_PASSWORD: ${{ secrets.cf_password }}
         run: |
           cf api ${CF_API_URL}
           cf auth
@@ -50,14 +51,14 @@ jobs:
 
       - name: Push to PaaS
         env:
-          ZENDESK_API_TOKEN: ${{ secrets.ZENDESK_API_TOKEN }}
-          ZENDESK_GROUP_ID: ${{ secrets.ZENDESK_GROUP_ID }}
-          ZENDESK_USERNAME: ${{ secrets.ZENDESK_USERNAME }}
+          ZENDESK_API_TOKEN: ${{ secrets.zendesk_api_token }}
+          ZENDESK_GROUP_ID: ${{ secrets.zendesk_group_id }}
+          ZENDESK_USERNAME: ${{ secrets.zendesk_username }}
         run: |
           cf push ${{ inputs.app_name }} \
-            --var register_spreadsheet_id=${{ secrets.REGISTER_SPREADSHEET_ID }} \
-            --var request_spreadsheet_id=${{ secrets.REQUEST_SPREADSHEET_ID }} \
-            --var use_stub_zendesk=${{ inputs.USE_STUB_ZENDESK }} \
+            --var register_spreadsheet_id=${{ secrets.register_spreadsheet_id }} \
+            --var request_spreadsheet_id=${{ secrets.request_spreadsheet_id }} \
+            --var use_stub_zendesk=${{ inputs.use_stub_zendesk }} \
             --var zendesk_api_token="${ZENDESK_API_TOKEN:- }" \
             --var zendesk_group_id="${ZENDESK_GROUP_ID:- }" \
             --var zendesk_username="${ZENDESK_USERNAME:- }"

--- a/.github/workflows/deploy-to-paas.yml
+++ b/.github/workflows/deploy-to-paas.yml
@@ -1,25 +1,33 @@
 name: Deploy to PaaS
 
 on:
-  push:
-    branches: [ main ]
+  workflow_call:
+    inputs:
+      environment: { required: true, type: string }
+      url: { required: false, type: string }
+      app_name: { required: false, type: string }
+      use_stub_zendesk: { required: true, type: boolean }
+    secrets:
+      CF_USERNAME: { required: true }
+      CF_PASSWORD: { required: true }
+      REGISTER_SPREADSHEET_ID: { required: true }
+      REQUEST_SPREADSHEET_ID: { required: true }
+      ZENDESK_API_TOKEN: { required: false }
+      ZENDESK_GROUP_ID: { required: false }
+      ZENDESK_USERNAME: { required: false }
 
 jobs:
-  deploy-test:
-    name: Deploy / Test
+  deploy:
+    name: Deploy to PaaS
     runs-on: ubuntu-latest
-    environment: test
+    environment:
+      name: ${{ inputs.environment }}
+      url: ${{ inputs.url }}
     steps:
-      - name: Pull repository
-        uses: actions/checkout@v2
-
-      - name: Install Node
-        uses: actions/setup-node@v2
+      - name: Get distribution artifact
+        uses: actions/download-artifact@v2
         with:
-          cache: 'npm'
-
-      - name: Install Node dependencies
-        run: npm install
+          name: product-pages
 
       - name: Install Cloud Foundry client
         env:
@@ -28,21 +36,11 @@ jobs:
           curl -sL ${CF_CLI_DOWNLOAD_URL} | sudo tar -zx -C /usr/local/bin
           cf version
 
-      - name: Build app
-        run: npm run build
-
-      - name: Prepare deployment directory
-        run: |
-          mkdir deploy && mkdir deploy/src/
-          cp -r dist/ deploy/dist/
-          cp -r src/views/ deploy/src/views
-          cp package*.json manifest.yml valid-email-domains.txt deploy/
-
       - name: PaaS login
         env:
           CF_API_URL: https://api.london.cloud.service.gov.uk
           CF_ORG_NAME: gds-digital-identity-onboarding
-          CF_SPACE_NAME: product-pages-test
+          CF_SPACE_NAME: product-pages-preview
           CF_USERNAME: ${{ secrets.CF_USERNAME }}
           CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
         run: |
@@ -51,11 +49,15 @@ jobs:
           cf target -o ${CF_ORG_NAME} -s ${CF_SPACE_NAME}
 
       - name: Push to PaaS
+        env:
+          ZENDESK_API_TOKEN: ${{ secrets.ZENDESK_API_TOKEN }}
+          ZENDESK_GROUP_ID: ${{ secrets.ZENDESK_GROUP_ID }}
+          ZENDESK_USERNAME: ${{ secrets.ZENDESK_USERNAME }}
         run: |
-          cd deploy
-          cf push --var "register_spreadsheet_id=${{ secrets.REGISTER_SPREADSHEET_ID }}" \
-                  --var "request_spreadsheet_id=${{ secrets.REQUEST_SPREADSHEET_ID }}" \
-                  --var "use_stub_zendesk=${{ secrets.USE_STUB_ZENDESK }}" \
-                  --var "zendesk_api_token=${{ secrets.ZENDESK_API_TOKEN }}" \
-                  --var "zendesk_group_id=''" \
-                  --var "zendesk_username=''"
+          cf push ${{ inputs.app_name }} \
+            --var register_spreadsheet_id=${{ secrets.REGISTER_SPREADSHEET_ID }} \
+            --var request_spreadsheet_id=${{ secrets.REQUEST_SPREADSHEET_ID }} \
+            --var use_stub_zendesk=${{ inputs.USE_STUB_ZENDESK }} \
+            --var zendesk_api_token="${ZENDESK_API_TOKEN:- }" \
+            --var zendesk_group_id="${ZENDESK_GROUP_ID:- }" \
+            --var zendesk_username="${ZENDESK_USERNAME:- }"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,33 +1,25 @@
 name: Deploy
 
 on:
-  workflow_call:
-    inputs:
-      environment: { required: true, type: string }
-      url: { required: false, type: string }
-      app_name: { required: false, type: string }
-      use_stub_zendesk: { required: true, type: boolean }
-    secrets:
-      CF_USERNAME: { required: true }
-      CF_PASSWORD: { required: true }
-      REGISTER_SPREADSHEET_ID: { required: true }
-      REQUEST_SPREADSHEET_ID: { required: true }
-      ZENDESK_API_TOKEN: { required: false }
-      ZENDESK_GROUP_ID: { required: false }
-      ZENDESK_USERNAME: { required: false }
+  push:
+    branches: [ main ]
 
 jobs:
-  deploy:
-    name: Deploy to PaaS
+  deploy-test:
+    name: Deploy / Test
     runs-on: ubuntu-latest
-    environment:
-      name: ${{ inputs.environment }}
-      url: ${{ inputs.url }}
+    environment: test
     steps:
-      - name: Get distribution artifact
-        uses: actions/download-artifact@v2
+      - name: Pull repository
+        uses: actions/checkout@v2
+
+      - name: Install Node
+        uses: actions/setup-node@v2
         with:
-          name: product-pages
+          cache: 'npm'
+
+      - name: Install Node dependencies
+        run: npm install
 
       - name: Install Cloud Foundry client
         env:
@@ -36,11 +28,21 @@ jobs:
           curl -sL ${CF_CLI_DOWNLOAD_URL} | sudo tar -zx -C /usr/local/bin
           cf version
 
+      - name: Build app
+        run: npm run build
+
+      - name: Prepare deployment directory
+        run: |
+          mkdir deploy && mkdir deploy/src/
+          cp -r dist/ deploy/dist/
+          cp -r src/views/ deploy/src/views
+          cp package*.json manifest.yml valid-email-domains.txt deploy/
+
       - name: PaaS login
         env:
           CF_API_URL: https://api.london.cloud.service.gov.uk
           CF_ORG_NAME: gds-digital-identity-onboarding
-          CF_SPACE_NAME: product-pages-preview
+          CF_SPACE_NAME: product-pages-test
           CF_USERNAME: ${{ secrets.CF_USERNAME }}
           CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
         run: |
@@ -49,15 +51,11 @@ jobs:
           cf target -o ${CF_ORG_NAME} -s ${CF_SPACE_NAME}
 
       - name: Push to PaaS
-        env:
-          ZENDESK_API_TOKEN: ${{ secrets.ZENDESK_API_TOKEN }}
-          ZENDESK_GROUP_ID: ${{ secrets.ZENDESK_GROUP_ID }}
-          ZENDESK_USERNAME: ${{ secrets.ZENDESK_USERNAME }}
         run: |
-          cf push ${{ inputs.app_name }} \
-            --var register_spreadsheet_id=${{ secrets.REGISTER_SPREADSHEET_ID }} \
-            --var request_spreadsheet_id=${{ secrets.REQUEST_SPREADSHEET_ID }} \
-            --var use_stub_zendesk=${{ inputs.USE_STUB_ZENDESK }} \
-            --var zendesk_api_token="${ZENDESK_API_TOKEN:- }" \
-            --var zendesk_group_id="${ZENDESK_GROUP_ID:- }" \
-            --var zendesk_username="${ZENDESK_USERNAME:- }"
+          cd deploy
+          cf push --var "register_spreadsheet_id=${{ secrets.REGISTER_SPREADSHEET_ID }}" \
+                  --var "request_spreadsheet_id=${{ secrets.REQUEST_SPREADSHEET_ID }}" \
+                  --var "use_stub_zendesk=${{ secrets.USE_STUB_ZENDESK }}" \
+                  --var "zendesk_api_token=${{ secrets.ZENDESK_API_TOKEN }}" \
+                  --var "zendesk_group_id=''" \
+                  --var "zendesk_username=''"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,16 +7,16 @@ on:
 jobs:
   build:
     name: Build
-    uses: alphagov/di-onboarding-product-page/.github/workflows/build.yml@95719f04dff575c2b468f69e49e50ef118228797
+    uses: alphagov/di-onboarding-product-page/.github/workflows/build.yml@0fc71869649811ea52287bc833949a78730c653e
 
   run-unit-tests:
     name: Run tests
-    uses: alphagov/di-onboarding-product-page/.github/workflows/run-unit-tests.yml@95719f04dff575c2b468f69e49e50ef118228797
+    uses: alphagov/di-onboarding-product-page/.github/workflows/run-unit-tests.yml@0fc71869649811ea52287bc833949a78730c653e
 
   deploy-test:
     name: Test
     needs: [build, run-unit-tests]
-    uses: alphagov/di-onboarding-product-page/.github/workflows/deploy-to-paas.yml@95719f04dff575c2b468f69e49e50ef118228797
+    uses: alphagov/di-onboarding-product-page/.github/workflows/deploy-to-paas.yml@0fc71869649811ea52287bc833949a78730c653e
     with:
       environment: test
       cf_space_name: product-pages-test
@@ -31,12 +31,12 @@ jobs:
   run-acceptance-tests:
     name: Run tests
     needs: deploy-test
-    uses: alphagov/di-onboarding-product-page/.github/workflows/run-acceptance-tests.yml@95719f04dff575c2b468f69e49e50ef118228797
+    uses: alphagov/di-onboarding-product-page/.github/workflows/run-acceptance-tests.yml@0fc71869649811ea52287bc833949a78730c653e
 
   deploy-production:
     name: Publish
     needs: run-acceptance-tests
-    uses: alphagov/di-onboarding-product-page/.github/workflows/deploy-to-paas.yml@95719f04dff575c2b468f69e49e50ef118228797
+    uses: alphagov/di-onboarding-product-page/.github/workflows/deploy-to-paas.yml@0fc71869649811ea52287bc833949a78730c653e
     with:
       environment: production
       cf_space_name: product-pages-production

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,9 +10,11 @@ on:
     secrets:
       CF_USERNAME: { required: true }
       CF_PASSWORD: { required: true }
-      ZENDESK_API_TOKEN: { required: true }
       REGISTER_SPREADSHEET_ID: { required: true }
       REQUEST_SPREADSHEET_ID: { required: true }
+      ZENDESK_API_TOKEN: { required: false }
+      ZENDESK_GROUP_ID: { required: false }
+      ZENDESK_USERNAME: { required: false }
 
 jobs:
   deploy:
@@ -47,11 +49,15 @@ jobs:
           cf target -o ${CF_ORG_NAME} -s ${CF_SPACE_NAME}
 
       - name: Push to PaaS
+        env:
+          ZENDESK_API_TOKEN: ${{ secrets.ZENDESK_API_TOKEN }}
+          ZENDESK_GROUP_ID: ${{ secrets.ZENDESK_GROUP_ID }}
+          ZENDESK_USERNAME: ${{ secrets.ZENDESK_USERNAME }}
         run: |
           cf push ${{ inputs.app_name }} \
-                  --var "register_spreadsheet_id=${{ secrets.REGISTER_SPREADSHEET_ID }}" \
-                  --var "request_spreadsheet_id=${{ secrets.REQUEST_SPREADSHEET_ID }}" \
-                  --var "use_stub_zendesk=${{ inputs.USE_STUB_ZENDESK }}" \
-                  --var "zendesk_api_token=${{ secrets.ZENDESK_API_TOKEN }}" \
-                  --var "zendesk_group_id=''" \
-                  --var "zendesk_username=''"
+            --var register_spreadsheet_id=${{ secrets.REGISTER_SPREADSHEET_ID }} \
+            --var request_spreadsheet_id=${{ secrets.REQUEST_SPREADSHEET_ID }} \
+            --var use_stub_zendesk=${{ inputs.USE_STUB_ZENDESK }} \
+            --var zendesk_api_token="${ZENDESK_API_TOKEN:- }" \
+            --var zendesk_group_id="${ZENDESK_GROUP_ID:- }" \
+            --var zendesk_username="${ZENDESK_USERNAME:- }"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,57 +5,45 @@ on:
     branches: [ main ]
 
 jobs:
+  build:
+    name: Build
+    uses: alphagov/di-onboarding-product-page/.github/workflows/build.yml@95719f04dff575c2b468f69e49e50ef118228797
+
+  run-unit-tests:
+    name: Run tests
+    uses: alphagov/di-onboarding-product-page/.github/workflows/run-unit-tests.yml@95719f04dff575c2b468f69e49e50ef118228797
+
   deploy-test:
-    name: Deploy / Test
-    runs-on: ubuntu-latest
-    environment: test
-    steps:
-      - name: Pull repository
-        uses: actions/checkout@v2
+    name: Test
+    needs: [build, run-unit-tests]
+    uses: alphagov/di-onboarding-product-page/.github/workflows/deploy-to-paas.yml@95719f04dff575c2b468f69e49e50ef118228797
+    with:
+      environment: test
+      cf_space_name: product-pages-test
+      url: https://di-product-page-test.london.cloudapps.digital
+      use_stub_zendesk: true
+    secrets:
+      cf_username: ${{ secrets.CF_USERNAME }}
+      cf_password: ${{ secrets.CF_PASSWORD }}
+      register_spreadsheet_id: ${{ secrets.REGISTER_SPREADSHEET_ID }}
+      request_spreadsheet_id: ${{ secrets.REQUEST_SPREADSHEET_ID }}
 
-      - name: Install Node
-        uses: actions/setup-node@v2
-        with:
-          cache: 'npm'
+  run-acceptance-tests:
+    name: Run tests
+    needs: deploy-test
+    uses: alphagov/di-onboarding-product-page/.github/workflows/run-acceptance-tests.yml@95719f04dff575c2b468f69e49e50ef118228797
 
-      - name: Install Node dependencies
-        run: npm install
-
-      - name: Install Cloud Foundry client
-        env:
-          CF_CLI_DOWNLOAD_URL: https://packages.cloudfoundry.org/stable?release=linux64-binary&source=github&version=v7
-        run: |
-          curl -sL ${CF_CLI_DOWNLOAD_URL} | sudo tar -zx -C /usr/local/bin
-          cf version
-
-      - name: Build app
-        run: npm run build
-
-      - name: Prepare deployment directory
-        run: |
-          mkdir deploy && mkdir deploy/src/
-          cp -r dist/ deploy/dist/
-          cp -r src/views/ deploy/src/views
-          cp package*.json manifest.yml valid-email-domains.txt deploy/
-
-      - name: PaaS login
-        env:
-          CF_API_URL: https://api.london.cloud.service.gov.uk
-          CF_ORG_NAME: gds-digital-identity-onboarding
-          CF_SPACE_NAME: product-pages-test
-          CF_USERNAME: ${{ secrets.CF_USERNAME }}
-          CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-        run: |
-          cf api ${CF_API_URL}
-          cf auth
-          cf target -o ${CF_ORG_NAME} -s ${CF_SPACE_NAME}
-
-      - name: Push to PaaS
-        run: |
-          cd deploy
-          cf push --var "register_spreadsheet_id=${{ secrets.REGISTER_SPREADSHEET_ID }}" \
-                  --var "request_spreadsheet_id=${{ secrets.REQUEST_SPREADSHEET_ID }}" \
-                  --var "use_stub_zendesk=${{ secrets.USE_STUB_ZENDESK }}" \
-                  --var "zendesk_api_token=${{ secrets.ZENDESK_API_TOKEN }}" \
-                  --var "zendesk_group_id=''" \
-                  --var "zendesk_username=''"
+  deploy-production:
+    name: Publish
+    needs: run-acceptance-tests
+    uses: alphagov/di-onboarding-product-page/.github/workflows/deploy-to-paas.yml@95719f04dff575c2b468f69e49e50ef118228797
+    with:
+      environment: production
+      cf_space_name: product-pages-production
+      url: https://di-product-page.london.cloudapps.digital
+      use_stub_zendesk: true
+    secrets:
+      cf_username: ${{ secrets.CF_USERNAME }}
+      cf_password: ${{ secrets.CF_PASSWORD }}
+      register_spreadsheet_id: ${{ secrets.REGISTER_SPREADSHEET_ID }}
+      request_spreadsheet_id: ${{ secrets.REQUEST_SPREADSHEET_ID }}

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -1,0 +1,10 @@
+name: Acceptance tests
+
+on: workflow_call
+
+jobs:
+  run-acceptance-tests:
+    name: Acceptance
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Ask John"

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -1,0 +1,20 @@
+name: Unit tests
+
+on: workflow_call
+
+jobs:
+  run-unit-tests:
+    name: Unit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull repository
+        uses: actions/checkout@v2
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          cache: 'npm'
+      - name: Install Node dependencies
+        run: npm install
+
+      - name: Run mocha tests
+        run: npm run test

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -35,7 +35,6 @@ jobs:
     secrets:
       CF_USERNAME: ${{ secrets.CF_USERNAME }}
       CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      ZENDESK_API_TOKEN: ${{ secrets.ZENDESK_API_TOKEN }}
       REGISTER_SPREADSHEET_ID: ${{ secrets.REGISTER_SPREADSHEET_ID }}
       REQUEST_SPREADSHEET_ID: ${{ secrets.REQUEST_SPREADSHEET_ID }}
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -10,13 +10,13 @@ applications:
       USE_STUB_SHEETS: false
       REGISTER_SHEET_DATA_RANGE: Register!A1
       REGISTER_SHEET_HEADER_RANGE: Register!A1:Y1
+      REGISTER_SPREADSHEET_ID: ((register_spreadsheet_id))
       REQUEST_SHEET_DATA_RANGE: "'Request to join private beta'!A1"
       REQUEST_SHEET_HEADER_RANGE: "'Request to join private beta'!A1:F1"
-      REGISTER_SPREADSHEET_ID: ((register_spreadsheet_id))
       REQUEST_SPREADSHEET_ID: ((request_spreadsheet_id))
+      ZENDESK_API_URL: https://govuk.zendesk.com/api/v2
+      ZENDESK_TAG: govuk-sign-in-service
       USE_STUB_ZENDESK: ((use_stub_zendesk))
       ZENDESK_GROUP_ID: ((zendesk_group_id))
       ZENDESK_USERNAME: ((zendesk_username))
-      ZENDESK_API_URL: https://govuk.zendesk.com/api/v2
       ZENDESK_API_TOKEN: ((zendesk_api_token))
-      ZENDESK_TAG: govuk-sign-in-service


### PR DESCRIPTION
**Complete the production pipeline**
    
Update the Deploy pipeline to use the shared workflows and deploy to the production environment if all tests have passed.

Both the build job and the unit tests must succeed for the deployment to the 'test' environment to go ahead. Deploy to the the production environment if acceptance tests have passed in 'test'.

Use lowercase for names of GHA inputs and secrets.

**Rename workflows for greater clarity**
    
Swap contents of deploy.yml and deploy-to-paas.yml

**Add reusable workflows for unit and acceptance tests**

**Handle empty config values**
    
Some config values are not present in non-prod environments yet `cf push` requires all env vars in the manifest file to be preset when deploying. Fix this by using env vars for the optional vars and use shell parameter expansion to substitute a white space if a value is not present.

The **Check PR** pipeline
<img width="1052" alt="Screenshot 2021-12-23 at 12 44 01" src="https://user-images.githubusercontent.com/3608562/147242304-eae93ef3-e622-433e-aeb2-6293a69b224f.png">
<img width="846" alt="Screenshot 2021-12-23 at 12 44 40" src="https://user-images.githubusercontent.com/3608562/147242319-52b802f0-09ac-45fc-8fde-9984096c8252.png">

The **Deploy** (production) pipeline
<img width="1050" alt="Screenshot 2021-12-23 at 14 42 49" src="https://user-images.githubusercontent.com/3608562/147256226-b0f2916a-c10c-48c5-addc-d122d430fe9d.png">
