### PR TITLE
Enable go back link to redirect to previous page on contact us page

### DIFF
--- a/src/views/contact-us.njk
+++ b/src/views/contact-us.njk
@@ -6,7 +6,7 @@
 
 {% block beforeContent %}
     <div class="govuk-width-container">
-        <a href="#" class="govuk-back-link">Back</a>
+        <a href="#" onclick="history.back()" class="govuk-back-link">Back</a>
     </div>
 {% endblock %}
 


### PR DESCRIPTION
Enable go back link to redirect to previous page on contact us page