### PR TITLE
DFA-376: Allow longer branch names in PR previews

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -18,8 +18,8 @@ jobs:
     with:
       environment: preview
       cf_space_name: product-pages-preview
-      app_name: di-product-page-preview-${{ github.head_ref }}
-      url: https://di-product-page-preview-${{ github.head_ref }}.london.cloudapps.digital
+      app_name: di-pp-prev-${{ github.head_ref }}
+      url: https://di-pp-prev-${{ github.head_ref }}.london.cloudapps.digital
       use_stub_zendesk: true
     secrets:
       cf_username: ${{ secrets.CF_USERNAME }}


### PR DESCRIPTION
PaaS imposes a limit of 63 characters for the host part of the app's URL.
The host name is constructed from the fixed prefix plus the branch name.
Use a shorter prefix to allow for longer branch names.