### PR TITLE
DFA-376: Validate preview deployment URL & clean up old deployments

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -14,12 +14,11 @@ jobs:
   deploy-preview:
     name: Preview
     needs: build
-    uses: alphagov/di-onboarding-product-page/.github/workflows/deploy-to-paas.yml@734f5c1128c60afb4063e1cd68a3f2da95e269f2
+    uses: alphagov/di-onboarding-product-page/.github/workflows/deploy-to-paas.yml@cbfc731a34387358e72744eac13b2a6b52fc2813
     with:
       environment: preview
       cf_space_name: product-pages-preview
       app_name: di-pp-prev-${{ github.head_ref }}
-      url: https://di-pp-prev-${{ github.head_ref }}.london.cloudapps.digital
     secrets:
       cf_username: ${{ secrets.CF_USERNAME }}
       cf_password: ${{ secrets.CF_PASSWORD }}

--- a/.github/workflows/delete-deployment.yml
+++ b/.github/workflows/delete-deployment.yml
@@ -2,6 +2,9 @@ name: Delete deployment
 
 on:
   workflow_dispatch:
+  schedule:
+    # Every weekday at 10am
+    - cron: '0 10 * * 1-5'
   pull_request:
     types: [closed]
 
@@ -31,7 +34,21 @@ jobs:
           cf target -o ${CF_ORG_NAME} -s ${CF_SPACE_NAME}
 
       - name: Delete app
+        if: ${{ github.event_name != 'schedule' }}
         run: |
           branch_name=$([[ ${{ github.event_name }} == 'pull_request' ]] && echo ${{ github.head_ref }} || echo ${{ github.ref_name }})
           app_name=$(echo di-pp-prev-${branch_name} | tr '[:upper:]' '[:lower:]' | tr '_' '-' | cut -c1-63)
           cf delete $app_name -rf
+
+      - name: Clean up stale deployments
+        if: ${{ github.event_name == 'schedule' }}
+        run: |
+          cut_off_date=$(date -d "30 days ago")
+          
+          for app in $(cf apps | awk 'NR>4 {print $1}')
+          do
+            last_deploy_date=$(date -d $(cf events $app | grep audit.app.package.upload | awk 'NR==1 {print $1}'))
+            if [[ $last_deploy_date < $cut_off_date ]]; then
+              cf delete $app -rf
+            fi
+          done

--- a/.github/workflows/delete-deployment.yml
+++ b/.github/workflows/delete-deployment.yml
@@ -32,4 +32,6 @@ jobs:
 
       - name: Delete app
         run: |
-          cf delete di-pp-prev-${{ github.head_ref }} -rf
+          branch_name=$([[ ${{ github.event_name }} == 'pull_request' ]] && echo ${{ github.head_ref }} || echo ${{ github.ref_name }})
+          app_name=$(echo di-pp-prev-${branch_name} | tr '[:upper:]' '[:lower:]' | tr '_' '-' | cut -c1-63)
+          cf delete $app_name -rf

--- a/.github/workflows/delete-deployment.yml
+++ b/.github/workflows/delete-deployment.yml
@@ -2,7 +2,6 @@ name: Delete deployment
 
 on:
   workflow_dispatch:
-  delete:
   pull_request:
     types: [closed]
 

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -10,12 +10,11 @@ jobs:
   deploy-preview:
     name: Preview
     needs: build
-    uses: alphagov/di-onboarding-product-page/.github/workflows/deploy-to-paas.yml@734f5c1128c60afb4063e1cd68a3f2da95e269f2
+    uses: alphagov/di-onboarding-product-page/.github/workflows/deploy-to-paas.yml@cbfc731a34387358e72744eac13b2a6b52fc2813
     with:
       environment: preview
       cf_space_name: product-pages-preview
-      app_name: di-pp-prev-${{ github.head_ref }}
-      url: https://di-pp-prev-${{ github.head_ref }}.london.cloudapps.digital
+      app_name: di-pp-prev-${{ github.ref_name }}
     secrets:
       cf_username: ${{ secrets.CF_USERNAME }}
       cf_password: ${{ secrets.CF_PASSWORD }}

--- a/.github/workflows/deploy-to-paas.yml
+++ b/.github/workflows/deploy-to-paas.yml
@@ -48,7 +48,7 @@ jobs:
         if: ${{ inputs.app_name != null }}
         run: |
           # Downcase the hostname and limit length to 63 characters as per PaaS requirements
-          hostname=$(echo ${{ inputs.app_name }} | tr '[:upper:]' '[:lower:]' | cut -c1-63)
+          hostname=$(echo ${{ inputs.app_name }} | tr '[:upper:]' '[:lower:]' | tr '_' '-' | cut -c1-63)
           echo "::set-output name=hostname::${hostname}"
 
       - name: Set deployment URL

--- a/.github/workflows/deploy-to-paas.yml
+++ b/.github/workflows/deploy-to-paas.yml
@@ -16,6 +16,10 @@ on:
       zendesk_api_token: { required: false }
       zendesk_group_id: { required: false }
       zendesk_username: { required: false }
+    outputs:
+      deployment_url:
+        description: "The PaaS deployment URL"
+        value: ${{ jobs.deploy.outputs.deployment_url }}
 
 jobs:
   deploy:
@@ -23,7 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: ${{ inputs.environment }}
-      url: ${{ inputs.url }}
+      url: ${{ steps.set_deployment_url.outputs.deployment_url }}
+    outputs:
+      deployment_url: ${{ steps.set_deployment_url.outputs.deployment_url }}
     steps:
       - name: Get distribution artifact
         uses: actions/download-artifact@v2
@@ -36,6 +42,22 @@ jobs:
         run: |
           curl -sL ${CF_CLI_DOWNLOAD_URL} | sudo tar -zx -C /usr/local/bin
           cf version
+
+      - name: Set deployment hostname
+        id: set_deployment_hostname
+        if: ${{ inputs.app_name != null }}
+        run: |
+          # Downcase the hostname and limit length to 63 characters as per PaaS requirements
+          hostname=$(echo ${{ inputs.app_name }} | tr '[:upper:]' '[:lower:]' | cut -c1-63)
+          echo "::set-output name=hostname::${hostname}"
+
+      - name: Set deployment URL
+        id: set_deployment_url
+        run: |
+          url=${{ inputs.url }}
+          hostname=${{ steps.set_deployment_hostname.outputs.hostname }}
+          deployment_url=$([[ $url ]] && echo $url || echo "https://${hostname}.london.cloudapps.digital")
+          echo "::set-output name=deployment_url::${deployment_url}"
 
       - name: PaaS login
         env:
@@ -55,7 +77,7 @@ jobs:
           ZENDESK_GROUP_ID: ${{ secrets.zendesk_group_id }}
           ZENDESK_USERNAME: ${{ secrets.zendesk_username }}
         run: |
-          cf push ${{ inputs.app_name }} \
+          cf push ${{ steps.set_deployment_hostname.outputs.hostname }} \
             --var register_spreadsheet_id=${{ secrets.register_spreadsheet_id }} \
             --var request_spreadsheet_id=${{ secrets.request_spreadsheet_id }} \
             --var use_stub_zendesk=${{ inputs.use_stub_zendesk }} \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
   deploy-test:
     name: Test
     needs: [build, run-unit-tests]
-    uses: alphagov/di-onboarding-product-page/.github/workflows/deploy-to-paas.yml@734f5c1128c60afb4063e1cd68a3f2da95e269f2
+    uses: alphagov/di-onboarding-product-page/.github/workflows/deploy-to-paas.yml@cbfc731a34387358e72744eac13b2a6b52fc2813
     with:
       environment: test
       cf_space_name: product-pages-test
@@ -35,12 +35,11 @@ jobs:
   deploy-production:
     name: Publish
     needs: run-acceptance-tests
-    uses: alphagov/di-onboarding-product-page/.github/workflows/deploy-to-paas.yml@734f5c1128c60afb4063e1cd68a3f2da95e269f2
+    uses: alphagov/di-onboarding-product-page/.github/workflows/deploy-to-paas.yml@cbfc731a34387358e72744eac13b2a6b52fc2813
     with:
       environment: production
       cf_space_name: product-pages-production
       url: https://di-product-page.london.cloudapps.digital
-      use_stub_zendesk: true
     secrets:
       cf_username: ${{ secrets.CF_USERNAME }}
       cf_password: ${{ secrets.CF_PASSWORD }}


### PR DESCRIPTION
PaaS requires URLs to be all lower case and the hostname portion can't exceed 63 characters. This means we have to transform the {prefix-branch_name} hostname before deploying.

The URL is constructed from the app name, when passed in, on the "Deploy to PaaS" workflow call.

Fix the script to manually depete a deployment - it now uses the correct branch name.

Add a script to clean up old deployments on schedule.