### PR TITLE
DFA-476 Update URLs in support page

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -274,10 +274,10 @@ app.post('/support', async (req, res) => {
       res.redirect('/contact-us-details');
     }
     if(req.body.support === 'gov-service-uses-sign-in') {
-      res.redirect('/service-team-support-form');
+      res.redirect('/contact-us');
     }
     if(req.body.support === 'gov-service-is-public') {
-      res.redirect('/contact-us?supportType=PUBLIC');
+      res.redirect('https://signin.account.gov.uk/contact-us?supportType=PUBLIC');
     }
   }
 


### PR DESCRIPTION
Update URLs used so members of the public go to the signin.account.gov.uk contact form and government services go to our contact form.