### PR TITLE
DFA-348: Pull through the Zendesk group ID to the prod deployment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,5 +48,6 @@ jobs:
     secrets:
       cf_username: ${{ secrets.CF_USERNAME }}
       cf_password: ${{ secrets.CF_PASSWORD }}
+      zendesk_group_id: ${{ secrets.ZENDESK_GROUP_ID }}
       register_spreadsheet_id: ${{ secrets.REGISTER_SPREADSHEET_ID }}
       request_spreadsheet_id: ${{ secrets.REQUEST_SPREADSHEET_ID }}


### PR DESCRIPTION
This is needed to make Zendesk integration work