### PR TITLE
BAU: Make links to our pages relative

### DIFF
--- a/src/views/accessibility.njk
+++ b/src/views/accessibility.njk
@@ -36,7 +36,7 @@
 
         <p class="govuk-body">
           This accessibility statement only contains information about the
-          <a href="https://www.sign-in.service.gov.uk" class="govuk-link">GOV.UK Sign In website</a>.
+          <a href="/" class="govuk-link">GOV.UK Sign In website</a>.
         </p>
 
         <p class="govuk-body">

--- a/src/views/identity-checks.njk
+++ b/src/views/identity-checks.njk
@@ -64,7 +64,7 @@
 
         <h2 class="govuk-heading-m">Help us design the identity checks</h2>
 
-        <p class="govuk-body"><a class="govuk-link" href="https://www.sign-in.service.gov.uk/register">Register your interest</a> to:</p>
+        <p class="govuk-body"><a class="govuk-link" href="/register">Register your interest</a> to:</p>
 
         <ul class="govuk-list govuk-list--bullet">
           <li>

--- a/src/views/privacy-policy.njk
+++ b/src/views/privacy-policy.njk
@@ -44,7 +44,7 @@
 
         <p class="govuk-body">
           Cabinet Office is the data controller for pages starting with
-          <a href="https://www.sign-in.service.gov.uk" class="govuk-link">sign-in.service.gov.uk</a>.
+          <a href="/" class="govuk-link">sign-in.service.gov.uk</a>.
         </p>
 
         <p class="govuk-body">


### PR DESCRIPTION
Don't hard code the domain so the relative links points to their relative URLs in different environments