### PR TITLE
DFA-348: Update production deployment URL

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
     with:
       environment: production
       cf_space_name: product-pages-production
-      url: https://di-product-page.london.cloudapps.digital
+      url: https://www.sign-in.service.gov.uk/
       rolling_deployment: true
       instances: 3
       use_stub_zendesk: false


### PR DESCRIPTION
We have now gone live and will be using the public URL from now on to refer to production.