### PR TITLE
BAU Add steps for Zendesk and Sheets forms

### DIFF
--- a/features/contact-us.feature
+++ b/features/contact-us.feature
@@ -9,8 +9,9 @@ Feature: A contact us form so users can contact us
 
     Given that the users enter alphanumeric characters into all of the fields in the contact us form
     When they select the Submit button
-    Then they should be directed to the following page: "/contact-us-submitted"
-    And their data is sent to Zendesk
+    Then their data is sent to Zendesk
+    And they should be directed to the following page: "/contact-us-submitted"
+    And they should see the text "Your message has been submitted"
 
   Scenario: The user doesn't complete the name field
 

--- a/features/request-private-beta.feature
+++ b/features/request-private-beta.feature
@@ -4,8 +4,9 @@ Feature: A request private beta form so service teams can request access to the 
 
     Given that the users enter alphanumeric characters into all of the fields in the request access to private beta form
     When they select the Submit button
-    Then they should be directed to the following page: "/decide/private-beta/request-submitted"
-    And their data is saved in the spreadsheet
+    Then their data is saved in the spreadsheet
+    And they should be directed to the following page: "/decide/private-beta/request-submitted"
+    And they should see the text "Thank you for requesting to join our private beta. We'll be in touch within five working days."
 
   Scenario: The user doesn't complete the name field
 

--- a/features/support/steps/shared-steps.ts
+++ b/features/support/steps/shared-steps.ts
@@ -43,8 +43,7 @@ Then('they should be directed to a page with the title {string}', async function
 });
 
 Then('their data is saved in the spreadsheet', async function () {
-    // we can't reliably test this but if we're on the above page, we should be okay
-    return true;
+    // we can't check the sheet but if we're on the right page and can find some content then that's good enough
 });
 
 Then('the error message {string} must be displayed for the {string} field', async function (errorMessage, field) {
@@ -69,6 +68,11 @@ Then('the error message {string} must be displayed for the {string} radios', asy
     assert.notEqual(messageAboveElement.length, 0, `Expected to find the message ${errorMessage} above the ${field} field.`);
     const actualMessageAboveSummary = await this.page.evaluate((el: { textContent: any; }) => el.textContent, messageAboveElement[0]);
     assert.equal(actualMessageAboveSummary.trim(), "Error: " + errorMessage, `Expected the message above the ${field} field to be ${errorMessage}`);
+});
+
+Then('they should see the text {string}', async function (text) {
+    let bodyText: string = await this.page.$eval('body', (element: any) => element.textContent)
+    assert.equal(bodyText.includes(text), true, `Body text does not contain "${text}"`)
 });
 
 Then('the {string} link will point to the following URL: {string}', async function (linkText, expectedUrl) {

--- a/features/support/steps/support-steps.ts
+++ b/features/support/steps/support-steps.ts
@@ -1,4 +1,4 @@
-import {Given, When} from "@cucumber/cucumber";
+import {When} from "@cucumber/cucumber";
 
 When('they select the {string} button', async function (id) {
     await Promise.all([

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "./dist",                        /* Redirect output structure to the directory. */
-    "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    //"rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
     // "removeComments": true,                /* Do not emit comments to output. */


### PR DESCRIPTION
Add a step to check the content of the success page for forms that post to Zendesk or Sheets.

We still need a feature file for the register pages but we're waiting for the ACs.

Comment out `rootDir` in `tsconfig.json`; typescript can still find what it needs but IntelliJ no longer gets upset when you include the shared functions in a step.