### PR TITLE
BAU Fix back links

### DIFF
--- a/src/views/contact-us-details.njk
+++ b/src/views/contact-us-details.njk
@@ -6,7 +6,7 @@
 
 {% block beforeContent %}
   <div class="govuk-width-container">
-    <a href="#" class="govuk-back-link">Back</a>
+    <a href="/support" class="govuk-back-link">Back</a>
   </div>
 {% endblock %}
 

--- a/src/views/contact-us.njk
+++ b/src/views/contact-us.njk
@@ -6,7 +6,7 @@
 
 {% block beforeContent %}
     <div class="govuk-width-container">
-        <a href="#" onclick="history.back()" class="govuk-back-link">Back</a>
+        <a href="/support" class="govuk-back-link">Back</a>
     </div>
 {% endblock %}
 


### PR DESCRIPTION
The back links on contact-us and contact-us-details weren't working (one used JavaScript from a time when we didn't know where back was going to be).