### PR TITLE
DFA-541 Dynamic back link

### DIFF
--- a/features/decide-contact-links.feature
+++ b/features/decide-contact-links.feature
@@ -3,11 +3,11 @@ Feature: Common links users can click to contact the service
   Scenario Outline:
     Given that the user is on the <page> page
     Then the Slack link will contain the correct URL
-    And the "online form" link will point to the following page: "/contact-us"
+    And the "online form" link will point to the following page: "/contact-us" with the parameter string <parameter_string>
 
     Examples:
-      | page                                     |
-      | "/decide"                                |
-      | "/decide/user-journeys"                  |
-      | "/decide/design-patterns"                |
-      | "/decide/private-beta/request-submitted" |
+      | page                                     | parameter_string                               |
+      | "/decide"                                | "?source=decide"                                |
+      | "/decide/user-journeys"                  | "?source=decide-user-journeys"                  |
+      | "/decide/design-patterns"                | "?source=decide-design-patterns"                |
+      | "/decide/private-beta/request-submitted" | "?source=decide-private-beta-request-submitted" |

--- a/features/support.feature
+++ b/features/support.feature
@@ -16,7 +16,7 @@ Feature: A support page which directs users to the correct type of support
   Scenario: the user is from a service team having issues
     When the user selects the "I work in a government service team that is setting up or already using GOV.UK Sign In" radio button
     And they select the "continue" button
-    Then they should be directed to the following page: "/contact-us"
+    Then they should be directed to the following page: "/contact-us?source=support"
 
   Scenario: the user doesn't pick an option
     When they select the "continue" button

--- a/features/support/steps/decide-contact-links-steps.ts
+++ b/features/support/steps/decide-contact-links-steps.ts
@@ -16,5 +16,3 @@ Then('the online form link on the main decide page will contain the correct URL'
   let link = await getLink(this.page,  contactUsText);
   await checkUrl(this.page, link, contactUsUrl);
 });
-
-

--- a/features/support/steps/shared-steps.ts
+++ b/features/support/steps/shared-steps.ts
@@ -84,3 +84,8 @@ Then('the {string} link will point to the following page: {string}', async funct
     let link = await getLink(this.page, linkText);
     await checkUrl(this.page, link, expectedPage);
 });
+
+Then('the {string} link will point to the following page: {string} with the parameter string {string}', async function (linkText: string, page: string, parameterString: string) {
+    let link = await getLink(this.page, linkText);
+    await checkUrl(this.page, link, page + parameterString);
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -54,18 +54,6 @@ app.get('/decide', (req, res) => {
     res.render('decide.njk');
 });
 
-app.get('/contact-us', (req, res) => {
-    const errorMessages = new Map();
-    const values = new Map();
-    res.render('contact-us.njk', {errorMessages: errorMessages, values: values});
-});
-
-app.get('/contact-us', (req, res) => {
-    const errorMessages = new Map();
-    const values = new Map();
-    res.render('contact-us.njk', {errorMessages: errorMessages, values: values});
-});
-
 app.get('/decide/timescales', (req, res) => {
     res.render('decide-timescales.njk');
 });
@@ -204,6 +192,17 @@ app.post('/decide/private-beta/request-form', async (req, res) => {
     }
 });
 
+app.get('/contact-us', (req, res) => {
+    const errorMessages = new Map();
+    const values = new Map();
+
+    res.render('contact-us.njk', {
+        errorMessages: errorMessages,
+        values: values,
+        backLinkDetails: getBackLinkDetails(req.query.source as string)
+    });
+});
+
 app.post('/contact-us', async (req, res) => {
     const values = new Map<string, string>(Object.entries(req.body));
     values.forEach((value, key) => values.set(key, value.trim()));
@@ -246,10 +245,41 @@ app.post('/contact-us', async (req, res) => {
                         "organisation-name",
                         "service-name",
                         "how-can-we-help"
-                    ]
+                    ],
+                backLinkDetails: getBackLinkDetails(req.query.source as string)
             });
     }
 });
+
+function getBackLinkDetails(source: string | undefined): Object {
+    let backLink: string | undefined;
+
+    switch (source) {
+        case "support":
+            backLink = "/support"
+            break;
+        case "contact-us-details":
+            backLink = "/contact-us-details"
+            break;
+        case "decide":
+            backLink = "/decide"
+            break;
+        case "decide-user-journeys":
+            backLink = "/decide/user-journeys"
+            break;
+        case "decide-design-patterns":
+            backLink = "/decide/design-patterns"
+            break;
+        case "decide-private-beta-request-submitted":
+            backLink = "/decide/private-beta/request-submitted"
+            break;
+        default:
+            backLink = "/support"
+            source = "support";
+    }
+
+    return {source: source, backLink: backLink};
+}
 
 app.get('/contact-us-submitted', (req, res) => {
     res.render('contact-us-confirm.njk');
@@ -271,7 +301,7 @@ app.post('/support', async (req, res) => {
             res.redirect('/contact-us-details');
         }
         if (req.body.support === 'gov-service-uses-sign-in') {
-            res.redirect('/contact-us');
+            res.redirect('/contact-us?source=support');
         }
         if (req.body.support === 'gov-service-is-public') {
             res.redirect('https://signin.account.gov.uk/contact-us?supportType=PUBLIC');

--- a/src/views/contact-us-details.njk
+++ b/src/views/contact-us-details.njk
@@ -29,7 +29,7 @@
         </ul>
 
         <p class="govuk-body">
-          Or if you still have questions, you can contact us using our <a class="govuk-link" href="/contact-us ">online form</a> or via our <a class="govuk-link" href="https://ukgovernmentdigital.slack.com/archives/C02AQUJ6WTC">Slack channel</a>.
+          Or if you still have questions, you can contact us using our <a class="govuk-link" href="/contact-us?source=contact-us-details">online form</a> or via our <a class="govuk-link" href="https://ukgovernmentdigital.slack.com/archives/C02AQUJ6WTC">Slack channel</a>.
         </p>
 
       </div>

--- a/src/views/contact-us.njk
+++ b/src/views/contact-us.njk
@@ -6,7 +6,7 @@
 
 {% block beforeContent %}
     <div class="govuk-width-container">
-        <a href="/support" class="govuk-back-link">Back</a>
+        <a href="{{backLinkDetails.backLink}}" class="govuk-back-link">Back</a>
     </div>
 {% endblock %}
 
@@ -51,7 +51,7 @@
                     <li>suggest improvements</li>
                 </ul>
 
-                <form class="form" method="post" novalidate="novalidate">
+                <form class="form" method="post" novalidate="novalidate" action="/contact-us?source={{backLinkDetails.source}}">
                     <fieldset class="govuk-fieldset">
                         <div class="govuk-form-group {% if errorMessages.get('name') %}govuk-form-group--error{% endif %}">
                             <label class="govuk-label" for="name">

--- a/src/views/decide-design-patterns.njk
+++ b/src/views/decide-design-patterns.njk
@@ -51,7 +51,7 @@
         <h2 class="govuk-heading-m">Contact us</h2>
 
         <p class="govuk-body">
-          If you cannot access the files or need the information presented in a different way, contact us using our <a class="govuk-link" href="/contact-us">online form</a> or via our <a class="govuk-link" href="https://ukgovernmentdigital.slack.com/archives/C02AQUJ6WTC">Slack channel</a>.
+          If you cannot access the files or need the information presented in a different way, contact us using our <a class="govuk-link" href="/contact-us?source=decide-design-patterns">online form</a> or via our <a class="govuk-link" href="https://ukgovernmentdigital.slack.com/archives/C02AQUJ6WTC">Slack channel</a>.
         </p>
 
         <p class="govuk-body">

--- a/src/views/decide-user-journeys.njk
+++ b/src/views/decide-user-journeys.njk
@@ -61,7 +61,7 @@
         <h2 class="govuk-heading-m">Contact us</h2>
 
         <p class="govuk-body">
-          If you cannot access the files or need the information presented in a different way, contact us using our <a class="govuk-link" href="/contact-us">online form</a> or via our <a class="govuk-link" href="https://ukgovernmentdigital.slack.com/archives/C02AQUJ6WTC">Slack channel</a>.
+          If you cannot access the files or need the information presented in a different way, contact us using our <a class="govuk-link" href="/contact-us?source=decide-user-journeys">online form</a> or via our <a class="govuk-link" href="https://ukgovernmentdigital.slack.com/archives/C02AQUJ6WTC">Slack channel</a>.
         </p>
 
         <p class="govuk-body">

--- a/src/views/decide.njk
+++ b/src/views/decide.njk
@@ -97,7 +97,7 @@
         <h2 class="govuk-heading-m evaluate-contact-us-decide">Contact us</h2>
 
         <p class="govuk-body">
-          Use our <a class="govuk-link" href="/contact-us">online form</a> to report problems, ask questions or suggest improvements.
+          Use our <a class="govuk-link" href="/contact-us?source=decide">online form</a> to report problems, ask questions or suggest improvements.
         </p>
 
         <p class="govuk-body">

--- a/src/views/request-submitted.njk
+++ b/src/views/request-submitted.njk
@@ -22,7 +22,7 @@
 
                 <p class="govuk-body">
                     If you have any questions in the meantime, contact us using our
-                    <a class="govuk-link" href="/contact-us">online form</a>
+                    <a class="govuk-link" href="/contact-us?source=decide-private-beta-request-submitted">online form</a>
                     or via our <a class="govuk-link" href="https://ukgovernmentdigital.slack.com/archives/C02AQUJ6WTC">Slack channel</a>.
                 </p>
 


### PR DESCRIPTION
Change behaviour of back link on /contact-us so that it points to the page the user has come from.

In the case that the user goes directly to /contact-us or the `source` queryParameter is incorrectly input the will be sent back to the /support page.

The form is updated with an `action` parameter to ensure the correct back link is displayed when there is an error with user input.
