### PR TITLE
BAU: Update link to technical documentation

### DIFF
--- a/features/base-template.feature
+++ b/features/base-template.feature
@@ -16,6 +16,6 @@ Feature: A base template that is used for pages that are not part of the evaluat
       | menu item         | page                                              |
       | "Identity checks" | "/identity-checks"                                |
       | "Find out more"   | "/find-out-more"                                  |
-      | "Documentation"   | "https://auth-tech-docs.london.cloudapps.digital" |
+      | "Documentation"   | "https://docs.sign-in.service.gov.uk"             |
       | "Support"         | "/support"                                        |
       | "Get started"     | "/getting-started"                                |

--- a/features/decide.feature
+++ b/features/decide.feature
@@ -25,7 +25,7 @@ Feature: Decide page
   Scenario: Read the technical documentation
 
     When they click on the "Technical documentation" link
-    Then they should be directed to a page with the title "Authentication Technical Docs - GOV.UK Sign In"
+    Then they should be directed to a page with the title "Authentication Technical Docs - Sign In"
 
   Scenario: Want to join the private beta
 

--- a/features/support/steps/decide-steps.ts
+++ b/features/support/steps/decide-steps.ts
@@ -11,7 +11,7 @@ Then('the left-hand navigation menu is displayed', async function () {
     assertElementFound(userJourneys, "User journeys");
     let designPatterns = await this.page.$x(`//nav[@class="sub-navigation"]/ul[contains(@class, "govuk-list")]//a[@href="/decide/design-patterns" and contains(text(), "Design patterns")]`);
     assertElementFound(designPatterns, "Design patterns");
-    let techDocs = await this.page.$x(`//nav[@class="sub-navigation"]/ul[contains(@class, "govuk-list")]//a[@href="https://auth-tech-docs.london.cloudapps.digital/#gov-uk-sign-in" and contains(text(), "Technical documentation")]`);
+    let techDocs = await this.page.$x(`//nav[@class="sub-navigation"]/ul[contains(@class, "govuk-list")]//a[@href="https://docs.sign-in.service.gov.uk/#gov-uk-sign-in" and contains(text(), "Technical documentation")]`);
     assertElementFound(techDocs, "Technical documentation");
     let requestToJoin = await this.page.$x(`//nav[@class="sub-navigation"]/ul[contains(@class, "govuk-list")]//a[@href="/decide/private-beta" and contains(text(), "Request to join private beta")]`);
     assertElementFound(requestToJoin, "Request to join private beta");

--- a/src/views/base-evaluate.njk
+++ b/src/views/base-evaluate.njk
@@ -5,6 +5,8 @@
 
 {% set assetPath = "/dist" %}
 
+{% set documentationUrl = "https://docs.sign-in.service.gov.uk" %}
+
 {% block head %}
   <!--[if !IE 8]><!-->
   <link rel="stylesheet" type="text/css" href="/dist/app.css">

--- a/src/views/base.njk
+++ b/src/views/base.njk
@@ -5,6 +5,8 @@
 
 {% set assetPath = "/dist" %}
 
+{% set documentationUrl = "https://docs.sign-in.service.gov.uk" %}
+
 {% block head %}
   <!--[if !IE 8]><!-->
   <link rel="stylesheet" type="text/css" href="/dist/app.css">
@@ -112,7 +114,7 @@
                 </a>
               </li>
               <li class="govuk-header__navigation-item">
-                <a class="govuk-header__link" href="https://auth-tech-docs.london.cloudapps.digital">
+                <a class="govuk-header__link" href="{{ documentationUrl }}">
                   Documentation
                 </a>
               </li>

--- a/src/views/decide-design-patterns.njk
+++ b/src/views/decide-design-patterns.njk
@@ -24,7 +24,7 @@
               <a class="govuk-link govuk-link--no-visited-state" href="/decide/design-patterns">Design patterns</a>
             </li>
             <li class="sub-navigation__item">
-              <a class="govuk-link govuk-link--no-visited-state" href="https://auth-tech-docs.london.cloudapps.digital/#gov-uk-sign-in">Technical documentation</a>
+              <a class="govuk-link govuk-link--no-visited-state" href="{{ documentationUrl }}/#gov-uk-sign-in">Technical documentation</a>
             </li>
             <li class="sub-navigation__item">
               <a class="govuk-link govuk-link--no-visited-state" href="/decide/private-beta">Request to join private beta</a>

--- a/src/views/decide-private-beta.njk
+++ b/src/views/decide-private-beta.njk
@@ -25,7 +25,7 @@
               <a class="govuk-link govuk-link--no-visited-state" href="/decide/design-patterns">Design patterns</a>
             </li>
             <li class="sub-navigation__item">
-              <a class="govuk-link govuk-link--no-visited-state" href="https://auth-tech-docs.london.cloudapps.digital/#gov-uk-sign-in">Technical documentation</a>
+              <a class="govuk-link govuk-link--no-visited-state" href="{{ documentationUrl }}/#gov-uk-sign-in">Technical documentation</a>
             </li>
             <li class="sub-navigation__item sub-navigation__item--active">
               <a class="govuk-link govuk-link--no-visited-state" href="/decide/private-beta">Request to join private beta</a>

--- a/src/views/decide-timescales.njk
+++ b/src/views/decide-timescales.njk
@@ -24,7 +24,7 @@
               <a class="govuk-link govuk-link--no-visited-state" href="/decide/design-patterns">Design patterns</a>
             </li>
             <li class="sub-navigation__item">
-              <a class="govuk-link govuk-link--no-visited-state" href="https://auth-tech-docs.london.cloudapps.digital/#gov-uk-sign-in">Technical documentation</a>
+              <a class="govuk-link govuk-link--no-visited-state" href="{{ documentationUrl }}/#gov-uk-sign-in">Technical documentation</a>
             </li>
             <li class="sub-navigation__item">
               <a class="govuk-link govuk-link--no-visited-state" href="/decide/private-beta">Request to join private beta</a>

--- a/src/views/decide-user-journeys.njk
+++ b/src/views/decide-user-journeys.njk
@@ -24,7 +24,7 @@
               <a class="govuk-link govuk-link--no-visited-state" href="/decide/design-patterns">Design patterns</a>
             </li>
             <li class="sub-navigation__item">
-              <a class="govuk-link govuk-link--no-visited-state" href="https://auth-tech-docs.london.cloudapps.digital/#gov-uk-sign-in">Technical documentation</a>
+              <a class="govuk-link govuk-link--no-visited-state" href="{{ documentationUrl }}/#gov-uk-sign-in">Technical documentation</a>
             </li>
             <li class="sub-navigation__item">
               <a class="govuk-link govuk-link--no-visited-state" href="/decide/private-beta">Request to join private beta</a>

--- a/src/views/decide.njk
+++ b/src/views/decide.njk
@@ -24,7 +24,7 @@
               <a class="govuk-link govuk-link--no-visited-state" href="/decide/design-patterns">Design patterns</a>
             </li>
             <li class="sub-navigation__item">
-              <a class="govuk-link govuk-link--no-visited-state" href="https://auth-tech-docs.london.cloudapps.digital/#gov-uk-sign-in">Technical documentation</a>
+              <a class="govuk-link govuk-link--no-visited-state" href="{{ documentationUrl }}/#gov-uk-sign-in">Technical documentation</a>
             </li>
             <li class="sub-navigation__item">
               <a class="govuk-link govuk-link--no-visited-state" href="/decide/private-beta">Request to join private beta</a>
@@ -83,7 +83,7 @@
         </div>
 
         <p class="govuk-body">
-          Read our <a class="govuk-link" href="https://auth-tech-docs.london.cloudapps.digital/#gov-uk-sign-in">technical documentation</a>.
+          Read our <a class="govuk-link" href="{{ documentationUrl }}/#gov-uk-sign-in">technical documentation</a>.
         </p>
 
         <h2 class="govuk-heading-m">


### PR DESCRIPTION
We've recently set up a "proper" url rather than a default url provided by PaaS.
