### PR TITLE
DFA-558 Generic error page

### DIFF
--- a/features/decide-contact-links.feature
+++ b/features/decide-contact-links.feature
@@ -3,7 +3,7 @@ Feature: Common links users can click to contact the service
   Scenario Outline:
     Given that the user is on the <page> page
     Then the Slack link will contain the correct URL
-    And the "online form" link will point to the following page: "/contact-us"
+    And the "support form" link will point to the following page: "/contact-us"
 
     Examples:
       | page                                     |

--- a/features/support/steps/decide-contact-links-steps.ts
+++ b/features/support/steps/decide-contact-links-steps.ts
@@ -9,8 +9,8 @@ Then('the Slack link will contain the correct URL', async function () {
   await checkUrl(this.page, link, slackLinkUrl);
 });
 
-Then('the online form link on the main decide page will contain the correct URL', async function () {
-  let contactUsText: string = "online form"
+Then('the support form link on the main decide page will contain the correct URL', async function () {
+  let contactUsText: string = "support form"
   let contactUsUrl: string = "/contact-us"
 
   let link = await getLink(this.page,  contactUsText);

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import express, {NextFunction, Request, Response } from 'express';
 import configureViews from './lib/configureViews';
 
 import register from './routes/register'
@@ -29,6 +29,12 @@ app.use('/', support);
 app.use((req, res, next) => {
     res.status(404).render('404.njk');
 });
+
+app.use((err: unknown, req: Request, res: Response, next: NextFunction) => {
+    console.log(err);
+    res.status(500)
+    res.render('there-is-a-problem.njk', { showLinkToContactForm: (req.path !== '/contact-us') });
+})
 
 const port = process.env.PORT || 3000
 app.listen(port, () => console.log(`Server running; listening on port ${port}`));

--- a/src/views/contact-us-details.njk
+++ b/src/views/contact-us-details.njk
@@ -29,7 +29,7 @@
         </ul>
 
         <p class="govuk-body">
-          Or if you still have questions, you can contact us using our <a class="govuk-link" href="/contact-us ">online form</a> or via our <a class="govuk-link" href="https://ukgovernmentdigital.slack.com/archives/C02AQUJ6WTC">Slack channel</a>.
+          Or if you still have questions, you can contact us using our <a class="govuk-link" href="/contact-us ">support form</a> or via our <a class="govuk-link" href="https://ukgovernmentdigital.slack.com/archives/C02AQUJ6WTC">Slack channel</a>.
         </p>
 
       </div>

--- a/src/views/decide-design-patterns.njk
+++ b/src/views/decide-design-patterns.njk
@@ -51,7 +51,7 @@
         <h2 class="govuk-heading-m">Contact us</h2>
 
         <p class="govuk-body">
-          If you cannot access the files or need the information presented in a different way, contact us using our <a class="govuk-link" href="/contact-us">online form</a> or via our <a class="govuk-link" href="https://ukgovernmentdigital.slack.com/archives/C02AQUJ6WTC">Slack channel</a>.
+          If you cannot access the files or need the information presented in a different way, contact us using our <a class="govuk-link" href="/contact-us">support form</a> or via our <a class="govuk-link" href="https://ukgovernmentdigital.slack.com/archives/C02AQUJ6WTC">Slack channel</a>.
         </p>
 
         <p class="govuk-body">

--- a/src/views/decide-user-journeys.njk
+++ b/src/views/decide-user-journeys.njk
@@ -61,7 +61,7 @@
         <h2 class="govuk-heading-m">Contact us</h2>
 
         <p class="govuk-body">
-          If you cannot access the files or need the information presented in a different way, contact us using our <a class="govuk-link" href="/contact-us">online form</a> or via our <a class="govuk-link" href="https://ukgovernmentdigital.slack.com/archives/C02AQUJ6WTC">Slack channel</a>.
+          If you cannot access the files or need the information presented in a different way, contact us using our <a class="govuk-link" href="/contact-us">support form</a> or via our <a class="govuk-link" href="https://ukgovernmentdigital.slack.com/archives/C02AQUJ6WTC">Slack channel</a>.
         </p>
 
         <p class="govuk-body">

--- a/src/views/decide.njk
+++ b/src/views/decide.njk
@@ -97,7 +97,7 @@
         <h2 class="govuk-heading-m evaluate-contact-us-decide">Contact us</h2>
 
         <p class="govuk-body">
-          Use our <a class="govuk-link" href="/contact-us">online form</a> to report problems, ask questions or suggest improvements.
+          Use our <a class="govuk-link" href="/contact-us">support form</a> to report problems, ask questions or suggest improvements.
         </p>
 
         <p class="govuk-body">

--- a/src/views/request-submitted.njk
+++ b/src/views/request-submitted.njk
@@ -22,7 +22,7 @@
 
                 <p class="govuk-body">
                     If you have any questions in the meantime, contact us using our
-                    <a class="govuk-link" href="/contact-us">online form</a>
+                    <a class="govuk-link" href="/contact-us">support form</a>
                     or via our <a class="govuk-link" href="https://ukgovernmentdigital.slack.com/archives/C02AQUJ6WTC">Slack channel</a>.
                 </p>
 

--- a/src/views/there-is-a-problem.njk
+++ b/src/views/there-is-a-problem.njk
@@ -14,7 +14,7 @@
 
                 {%  if showLinkToContactForm %}
                     <p class="govuk-body">
-                        You can contact us using our <a class="govuk-link" href="/contact-us ">online form</a> if it happens again.
+                        You can contact us using our <a class="govuk-link" href="/contact-us ">support form</a> if it happens again.
                     </p>
                 {% endif %}
 

--- a/src/views/there-is-a-problem.njk
+++ b/src/views/there-is-a-problem.njk
@@ -1,0 +1,24 @@
+{% extends "base.njk" %}
+
+{% block pageTitle %}There is a problem with the service – GOV.UK Product Pages{% endblock %}
+
+{% set mainClasses = "govuk-main-wrapper govuk-main-wrapper--auto-spacing" %}
+
+{% block content %}
+    <div class="govuk-width-container">
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+                <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
+
+                <p class="govuk-body">Try again later.</p>
+
+                {%  if showLinkToContactForm %}
+                    <p class="govuk-body">
+                        You can contact us using our <a class="govuk-link" href="/contact-us ">online form</a> if it happens again.
+                    </p>
+                {% endif %}
+
+            </div>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
Add a view `there-is-a-problem.njk` to display when an unhandled error is thrown.
Add the `app.use` gubbins so that the page is displayed when an unhandled error is thrown.