### PR TITLE
DFA-528 Only load form validator once

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-import express, {NextFunction, Request, Response } from 'express';
+import express, {NextFunction, Request, Response} from 'express';
 import configureViews from './lib/configureViews';
 
 import register from './routes/register'
@@ -6,10 +6,12 @@ import decide from './routes/decide'
 import contactUs from './routes/contact-us'
 import site from "./routes/site";
 import support from './routes/support'
+import Validation from "./lib/validation";
 
 const app = express();
 const bodyParser = require('body-parser')
 
+app.set('validation', Validation.getInstance());
 app.use('/dist', express.static('./dist/assets'));
 app.use(express.static('./dist'));
 
@@ -33,7 +35,7 @@ app.use((req, res, next) => {
 app.use((err: unknown, req: Request, res: Response, next: NextFunction) => {
     console.log(err);
     res.status(500)
-    res.render('there-is-a-problem.njk', { showLinkToContactForm: (req.path !== '/contact-us') });
+    res.render('there-is-a-problem.njk', {showLinkToContactForm: (req.path !== '/contact-us')});
 })
 
 const port = process.env.PORT || 3000

--- a/src/controllers/contact-us.ts
+++ b/src/controllers/contact-us.ts
@@ -2,6 +2,15 @@ import { Request, Response } from 'express';
 import Validation from "../lib/validation";
 import ZendeskService from "../lib/zendesk/ZendeskService";
 
+let requiredFields = new Map<string, string>();
+requiredFields.set("email", "Enter your government email address");
+requiredFields.set("name", "Enter your name");
+requiredFields.set("role", "Enter your role");
+requiredFields.set("service-name", "Enter the name of your service");
+requiredFields.set("organisation-name", "Enter the name of your organisation");
+requiredFields.set("how-can-we-help", "Tell us how we can help");
+
+
 export const showForm = function(req: Request, res: Response) {
     const errorMessages = new Map();
     const values = new Map();
@@ -12,17 +21,7 @@ export const submitForm = async function(req: Request, res: Response) {
     const values = new Map<string, string>(Object.entries(req.body));
     values.forEach((value, key) => values.set(key, value.trim()));
 
-    let requiredFields = new Map<string, string>();
-    requiredFields.set("email", "Enter your government email address");
-    requiredFields.set("name", "Enter your name");
-    requiredFields.set("role", "Enter your role");
-    requiredFields.set("service-name", "Enter the name of your service");
-    requiredFields.set("organisation-name", "Enter the name of your organisation");
-    requiredFields.set("how-can-we-help", "Tell us how we can help");
-
-    const validator = new Validation(values, requiredFields);
-    await validator.loadExtendedEmailDomains();
-    const errorMessages = validator.validate();
+    const errorMessages = (req.app.get('validation') as Validation).validate(values, requiredFields);
 
     if (errorMessages.size == 0) {
         const zendesk = new ZendeskService(

--- a/src/controllers/decide.ts
+++ b/src/controllers/decide.ts
@@ -4,6 +4,12 @@ import Validation from "../lib/validation";
 import getTimestamp from "../lib/timestamp";
 import uuid from "../lib/uuid";
 
+let requiredFields = new Map<string, string>();
+requiredFields.set("email", "Enter your government email address");
+requiredFields.set("name", "Enter your name");
+requiredFields.set("service-name", "Enter the name of your service");
+requiredFields.set("department-name", "Enter your department");
+
 export const decide = function (req: Request, res: Response) {
     res.render('decide.njk');
 }
@@ -35,15 +41,7 @@ export const submitRequestForm = async function (req: Request, res: Response) {
     const values = new Map<string, string>(Object.entries(req.body));
     values.forEach((value, key) => values.set(key, value.trim()));
 
-    let requiredFields = new Map<string, string>();
-    requiredFields.set("email", "Enter your government email address");
-    requiredFields.set("name", "Enter your name");
-    requiredFields.set("service-name", "Enter the name of your service");
-    requiredFields.set("department-name", "Enter your department");
-
-    const validator = new Validation(values, requiredFields);
-    await validator.loadExtendedEmailDomains();
-    const errorMessages = validator.validate();
+    const errorMessages = (req.app.get('validation') as Validation).validate(values, requiredFields);
 
     if (errorMessages.size == 0) {
         values.set('id', uuid());

--- a/src/controllers/register.ts
+++ b/src/controllers/register.ts
@@ -1,8 +1,14 @@
-import { Request, Response, NextFunction } from 'express';
+import { Request, Response } from 'express';
 import Validation from "../lib/validation";
 import uuid from "../lib/uuid";
 import getTimestamp from "../lib/timestamp";
 import SheetsService from "../lib/sheets/SheetsService";
+
+let requiredFields = new Map<string, string>();
+requiredFields.set("email", "Enter your government email address");
+requiredFields.set("name", "Enter your name");
+requiredFields.set("service-name", "Enter the name of your service");
+requiredFields.set("organisation-name", "Enter your organisation name");
 
 export const get = function(req: Request, res: Response) {
     const errorMessages = new Map();
@@ -14,15 +20,7 @@ export const post = async function(req: Request, res: Response) {
     const values = new Map<string, string>(Object.entries(req.body));
     values.forEach((value, key) => values.set(key, value.trim()));
 
-    let requiredFields = new Map<string, string>();
-    requiredFields.set("email", "Enter your government email address");
-    requiredFields.set("name", "Enter your name");
-    requiredFields.set("service-name", "Enter the name of your service");
-    requiredFields.set("organisation-name", "Enter your organisation name");
-
-    const validator = new Validation(values, requiredFields);
-    await validator.loadExtendedEmailDomains();
-    const errorMessages = validator.validate();
+    const errorMessages = (req.app.get('validation') as Validation).validate(values, requiredFields);
 
     if (errorMessages.size == 0) {
         values.set('id', uuid());

--- a/src/lib/sheets/stubSheets/stubSheetsService.ts
+++ b/src/lib/sheets/stubSheets/stubSheetsService.ts
@@ -1,6 +1,3 @@
-import {promises as fs} from 'fs';
-import {JWT} from 'googleapis-common';
-import {google} from 'googleapis';
 import SheetsService from "../interface";
 
 export default class StubSheetsService implements SheetsService {

--- a/src/lib/validation/validation.spec.ts
+++ b/src/lib/validation/validation.spec.ts
@@ -2,6 +2,12 @@ import {assert} from 'chai'
 
 import Validation from './index'
 
+let validator: Validation;
+
+before( function() {
+    validator = new Validation();
+})
+
 describe('Validation tests', function () {
 
     let requiredFields = new Map<string, string>();
@@ -11,22 +17,22 @@ describe('Validation tests', function () {
     requiredFields.set("department-name", "Enter your department");
 
     it("doesn't return any errors for a valid form", function () {
-        assert.equal(new Validation(completedValidForm(), requiredFields).validate().size, 0);
+        assert.equal(validator.validate(completedValidForm(), requiredFields).size, 0);
     });
 
     it('returns 4 errors if the form is empty', function () {
-        assert.equal(new Validation(new Map<string, string>(), requiredFields).validate().size, 4, 'expected to see 4 errors');
+        assert.equal(validator.validate(new Map<string, string>(), requiredFields).size, 4, 'expected to see 4 errors');
     });
 
     it('does not accept foo@bar.com as a valid email address because it is not a government address', function () {
-        let emailError = new Validation(new Map<string, string>(Object.entries({email: "foo@bar.com"})), requiredFields).validate().get("email")
+        let emailError = validator.validate(new Map<string, string>(Object.entries({email: "foo@bar.com"})), requiredFields).get("email")
         assert.equal(emailError,
             "Enter a government email address",
             "There are three possible error conditions for the email field - empty, invalid, not a government email.");
     });
 
     it('does not accept foo@bar as a valid email address because the domain is incomplete', function () {
-        let emailError = new Validation(new Map<string, string>(Object.entries({email: "foo@bar"})), requiredFields).validate().get("email")
+        let emailError = validator.validate(new Map<string, string>(Object.entries({email: "foo@bar"})), requiredFields).get("email")
         assert.equal(emailError,
             "Enter an email address in the correct format, like name@gov.uk",
             "There are three possible error conditions for the email field - empty, invalid, not a government email.");
@@ -35,9 +41,7 @@ describe('Validation tests', function () {
     it('it accepts bl.uk as a valid email domain', async function() {
         let form = completedValidForm();
         form.set('email', "bookworm@bl.uk")
-        let validator = new Validation(form, requiredFields);
-        await validator.loadExtendedEmailDomains();
-        assert.equal(validator.validate().size, 0, "bl.uk is one of the domains in valid-email-domains.txt");
+        assert.equal(validator.validate(form, requiredFields).size, 0, "bl.uk is one of the domains in valid-email-domains.txt");
     })
 })
 

--- a/valid-email-domains.txt
+++ b/valid-email-domains.txt
@@ -1,3 +1,14 @@
+gov.uk
+nhs.uk
+nhs.net
+nhs.scot
+police.uk
+cjsm.net
+ac.uk
+sch.uk
+onevoicewales.wales
+suttonmail.org
+highwaysengland.co.uk
 aberdeencity.gov.uk
 aberdeencityandshire-sdpa.gov.uk
 aberdeenshire.gov.uk


### PR DESCRIPTION
The code which validates forms loads a file full of email addresses.  This was originally a quick fix to add the functionality as soon as possible.  This PR fixes the quick fix and only loads the file at app initialisation instead of every time a form is submitted.

* Change Validation class to provide a singleton type method for getting a single instance of the class. Pass form being validated and required fields in as arguments to the validation method instead of as arguments to a constructor.
* Load valid email domains synchronously
* Put all valid emails into a file - do not hardcode any
* Terminate execution if the file does not load
* Set the instance as a property of the app
* Use that app property in the controller methods that deal with form submissions.
* Update tests to use the new method signature.
* Remove unused imports
