### PR TITLE
BAU Change alerting channel

### DIFF
--- a/monitoring/template.yaml
+++ b/monitoring/template.yaml
@@ -57,7 +57,7 @@ Resources:
       Environment:
         Variables:
           WEBHOOK_PARAMETER_NAME: "canaries-slack-webhook-path"
-          SLACK_CHANNEL: "di-dfa-tech-notifications"
+          SLACK_CHANNEL: "di-dfa-alerts"
       Runtime: nodejs14.x
       Architectures:
         - x86_64


### PR DESCRIPTION
Alerts currently go to `di-dfa-tech-notifications` but should go to `di-dfa-alerts`.

Change `SLACK_CHANNEL` in the canaries template to have the value 'di-dfa-alerts`.

Once merged, this should run SAM which will update the lambda to use the new channel.