### PR TITLE
Remove status page link

### DIFF
--- a/features/contact-us.feature
+++ b/features/contact-us.feature
@@ -1,10 +1,5 @@
 Feature: A contact us form so users can contact us
 
-  Scenario: Check if there are unknown incidents
-
-    Given that the user is on the "/contact-us" page
-    Then the "status page" link will point to the following URL: "https://verifystatus.digital.cabinet-office.gov.uk/"
-
   Scenario: User contacts us and fills in the form correctly
 
     Given that the users enter alphanumeric characters into all of the fields in the contact us form

--- a/src/views/contact-us.njk
+++ b/src/views/contact-us.njk
@@ -34,11 +34,7 @@
                     Contact us
                 </h1>
 
-                <p class="govuk-body">If you have a problem, first check for known issues on our
-                    <a href="https://verifystatus.digital.cabinet-office.gov.uk/">status page</a>.
-                </p>
-
-                <p class="govuk-body">Otherwise, use this form to:</p>
+                <p class="govuk-body">Use this form to:</p>
                 <ul class="govuk-list govuk-list--bullet">
                     <li>report a problem</li>
                     <li>ask questions</li>


### PR DESCRIPTION
We need to remove the line. that links to the Verify status page, because this is really confusing. We were meant to have a new one, but it's taking a while so we should remove this in the meantime.