### PR TITLE
Update link text on private beta page

### DIFF
--- a/src/views/getting-started-private-beta.njk
+++ b/src/views/getting-started-private-beta.njk
@@ -55,7 +55,7 @@
           <li>be able to integrate with GOV.UK Sign In - this means you need access to developers who are comfortable working with the OpenID Connect (OIDC) protocol and the processes set out in our <a class="govuk-link" href="https://docs.sign-in.service.gov.uk/integrate-with-integration-environment">technical documentation</a></li>
         </ul>
         <h2 class="govuk-heading-m">The joining process</h2>
-        <p class="govuk-body">If you meet the beta criteria and would like to take part, <a class="govuk-link" href="/register">register your interest</a>.</p>
+        <p class="govuk-body">If you meet the beta criteria and would like to take part, <a class="govuk-link" href="/register">sign up to get access</a>.</p>
         <p class="govuk-body">You can then speak to us about your service and access our test environment. If you decide GOV.UK Sign In meets your needs, email us to let us know you’d like to join the beta.</p>
         <p class="govuk-body">After this, we’ll ask you to fill in a form and give us more detailed information about your service. This will include things like your user volumes and timelines.</p>
         <p class="govuk-body">We’ll review the information you send and let you know within 2 weeks whether you can join the beta.</p>


### PR DESCRIPTION
This is to make the link text reflect the new wording on the sign up form - it's now 'sign up to get access' instead of 'register your interest'.