### PR TITLE
BAU Update OIDC policy

### DIFF
--- a/ci/github-actions-aws-oidc-provider-template.yml
+++ b/ci/github-actions-aws-oidc-provider-template.yml
@@ -61,6 +61,7 @@ Resources:
                   - "lambda:GetFunction"
                   - "lambda:GetFunctionConfiguration"
                   - "lambda:GetLayerVersion"
+                  - "lambda:ListTags"
                   - "lambda:PublishLayerVersion"
                   - "lambda:PublishVersion"
                   - "lambda:UpdateFunction"


### PR DESCRIPTION
Canaries deployment fails because of a missing `lambda:ListTags` permission. Add this permission and see what else is missing when it fails again.