### PR TITLE
BAU: Bug fixes and formatting in feature tests

### DIFF
--- a/features/support/steps/base-template-steps.ts
+++ b/features/support/steps/base-template-steps.ts
@@ -1,5 +1,5 @@
-import {Given, When, Then} from "@cucumber/cucumber";
-import {assert} from "chai";
+import { Given, Then, When } from '@cucumber/cucumber';
+import { assert } from 'chai';
 
 
 Given('the user is browsing with a viewport {int} pixels wide', async function (width: number) {

--- a/features/support/steps/contact-us-steps.ts
+++ b/features/support/steps/contact-us-steps.ts
@@ -1,13 +1,9 @@
 import {Given, Then} from "@cucumber/cucumber";
 
 Given('that the users enter alphanumeric characters into all of the fields in the contact us form', async function () {
-    await this.goToPath("/contact-us");
-    await this.page.type('#email', 'tessa.ting@foo-bar.gov.uk');
-    await this.page.type("#name", 'Tessa Ting');
-    await this.page.type("#role", 'Chief Unicorn Tester');
-    await this.page.type("#service-name", "Unicorn Testing");
-    await this.page.type("#organisation-name", "Department of Sorcery");
-    await this.page.type("#how-can-we-help", "We'd like fairies to be able to sign up to get their unicorns tested.");
+    await this.goToPath('/contact-us');
+    await fillInUserInfoFields(this.page);
+    await this.page.type('#how-can-we-help', "We'd like fairies to be able to sign up to get their unicorns tested.");
 });
 
 Given('that the users enter alphanumeric characters into all of the fields in the contact us form except the name field', async function () {
@@ -55,12 +51,8 @@ Given('that the users enter alphanumeric characters into all of the fields in th
 });
 
 Given('that the users enter alphanumeric characters into all of the fields in the contact us form except the how-can-we-help field', async function () {
-    await this.goToPath("/contact-us");
-    await this.page.type('#email', 'tessa.ting@foo-bar.gov.uk');
-    await this.page.type("#name", 'Tessa Ting');
-    await this.page.type("#role", 'Chief Unicorn Tester');
-    await this.page.type("#service-name", "Unicorn Testing");
-    await this.page.type("#organisation-name", "Department of Sorcery");
+    await this.goToPath('/contact-us');
+    await fillInUserInfoFields(this.page);
 });
 
 Given('that the user enters an invalid email address into the email field of the contact us form', async function () {
@@ -77,3 +69,11 @@ Then('their data is sent to Zendesk', async function () {
     // We can't really test this unless we just run a unit test or something
     return true;
 });
+
+async function fillInUserInfoFields(page: Page) {
+    await page.type('#email', 'tessa.ting@foo-bar.gov.uk');
+    await page.type('#name', 'Tessa Ting');
+    await page.type('#role', 'Chief Unicorn Tester');
+    await page.type('#service-name', 'Unicorn Testing');
+    await page.type('#organisation-name', 'Department of Sorcery');
+}

--- a/features/support/steps/contact-us-steps.ts
+++ b/features/support/steps/contact-us-steps.ts
@@ -1,4 +1,5 @@
-import {Given, Then} from "@cucumber/cucumber";
+import { Given, Then } from '@cucumber/cucumber';
+import { Page } from 'puppeteer';
 
 Given('that the users enter alphanumeric characters into all of the fields in the contact us form', async function () {
     await this.goToPath('/contact-us');
@@ -7,47 +8,47 @@ Given('that the users enter alphanumeric characters into all of the fields in th
 });
 
 Given('that the users enter alphanumeric characters into all of the fields in the contact us form except the name field', async function () {
-    await this.goToPath("/contact-us");
-    await this.page.type("#role", 'Chief Unicorn Tester');
+    await this.goToPath('/contact-us');
+    await this.page.type('#role', 'Chief Unicorn Tester');
     await this.page.type('#email', 'tessa.ting@foo-bar.gov.uk');
-    await this.page.type("#service-name", "Unicorn Testing");
-    await this.page.type("#organisation-name", "Department of Sorcery");
-    await this.page.type("#how-can-we-help", "We'd like fairies to be able to sign up to get their unicorns tested.");
+    await this.page.type('#service-name', 'Unicorn Testing');
+    await this.page.type('#organisation-name', 'Department of Sorcery');
+    await this.page.type('#how-can-we-help', "We'd like fairies to be able to sign up to get their unicorns tested.");
 });
 
 Given('that the users enter alphanumeric characters into all of the fields in the contact us form except the email field', async function () {
-    await this.goToPath("/contact-us");
-    await this.page.type("#name", 'Tessa Ting');
-    await this.page.type("#role", 'Chief Unicorn Tester');
-    await this.page.type("#service-name", "Unicorn Testing");
-    await this.page.type("#organisation-name", "Department of Sorcery");
-    await this.page.type("#how-can-we-help", "We'd like fairies to be able to sign up to get their unicorns tested.");
+    await this.goToPath('/contact-us');
+    await this.page.type('#name', 'Tessa Ting');
+    await this.page.type('#role', 'Chief Unicorn Tester');
+    await this.page.type('#service-name', 'Unicorn Testing');
+    await this.page.type('#organisation-name', 'Department of Sorcery');
+    await this.page.type('#how-can-we-help', "We'd like fairies to be able to sign up to get their unicorns tested.");
 });
 
 Given('that the users enter alphanumeric characters into all of the fields in the contact us form except the role field', async function () {
-    await this.goToPath("/contact-us");
-    await this.page.type("#name", 'Tessa Ting');
-    await this.page.type("#service-name", "Unicorn Testing");
-    await this.page.type("#organisation-name", "Department of Sorcery");
-    await this.page.type("#how-can-we-help", "We'd like fairies to be able to sign up to get their unicorns tested.");
+    await this.goToPath('/contact-us');
+    await this.page.type('#name', 'Tessa Ting');
+    await this.page.type('#service-name', 'Unicorn Testing');
+    await this.page.type('#organisation-name', 'Department of Sorcery');
+    await this.page.type('#how-can-we-help', "We'd like fairies to be able to sign up to get their unicorns tested.");
 });
 
 Given('that the users enter alphanumeric characters into all of the fields in the contact us form except the organisation-name field', async function () {
-    await this.goToPath("/contact-us");
+    await this.goToPath('/contact-us');
     await this.page.type('#email', 'tessa.ting@foo-bar.gov.uk');
-    await this.page.type("#name", 'Tessa Ting');
-    await this.page.type("#role", 'Chief Unicorn Tester');
-    await this.page.type("#service-name", "Unicorn Testing");
-    await this.page.type("#how-can-we-help", "We'd like fairies to be able to sign up to get their unicorns tested.");
+    await this.page.type('#name', 'Tessa Ting');
+    await this.page.type('#role', 'Chief Unicorn Tester');
+    await this.page.type('#service-name', 'Unicorn Testing');
+    await this.page.type('#how-can-we-help', "We'd like fairies to be able to sign up to get their unicorns tested.");
 });
 
 Given('that the users enter alphanumeric characters into all of the fields in the contact us form except the service-name field', async function () {
-    await this.goToPath("/contact-us");
+    await this.goToPath('/contact-us');
     await this.page.type('#email', 'tessa.ting@foo-bar.gov.uk');
-    await this.page.type("#name", 'Tessa Ting');
-    await this.page.type("#role", 'Chief Unicorn Tester');
-    await this.page.type("#organisation-name", "Department of Sorcery");
-    await this.page.type("#how-can-we-help", "We'd like fairies to be able to sign up to get their unicorns tested.");
+    await this.page.type('#name', 'Tessa Ting');
+    await this.page.type('#role', 'Chief Unicorn Tester');
+    await this.page.type('#organisation-name', 'Department of Sorcery');
+    await this.page.type('#how-can-we-help', "We'd like fairies to be able to sign up to get their unicorns tested.");
 });
 
 Given('that the users enter alphanumeric characters into all of the fields in the contact us form except the how-can-we-help field', async function () {
@@ -56,12 +57,12 @@ Given('that the users enter alphanumeric characters into all of the fields in th
 });
 
 Given('that the user enters an invalid email address into the email field of the contact us form', async function () {
-    await this.goToPath("/contact-us");
+    await this.goToPath('/contact-us');
     await this.page.type('#email', '1 Station Road, Newtown, Countyshire AB1 2CD');
 });
 
 Given('that the user enters a non-government email address into the email field of the contact us form', async function () {
-    await this.goToPath("/contact-us");
+    await this.goToPath('/contact-us');
     await this.page.type('#email', 'bill@microsoft.com');
 });
 

--- a/features/support/steps/decide-contact-links-steps.ts
+++ b/features/support/steps/decide-contact-links-steps.ts
@@ -1,20 +1,18 @@
-import {Then} from "@cucumber/cucumber";
-import {getLink, checkUrl} from './shared-functions';
+import { Then } from '@cucumber/cucumber';
+import { checkUrl, getLink } from './shared-functions';
 
 Then('the Slack link will contain the correct URL', async function () {
-  let slackLinkText: string = "Slack channel"
-  let slackLinkUrl: string = "https://ukgovernmentdigital.slack.com/archives/C02AQUJ6WTC"
+    let slackLinkText: string = 'Slack channel'
+    let slackLinkUrl: string = 'https://ukgovernmentdigital.slack.com/archives/C02AQUJ6WTC'
 
-  let link = await getLink(this.page, slackLinkText);
-  await checkUrl(this.page, link, slackLinkUrl);
+    let link = await getLink(this.page, slackLinkText);
+    await checkUrl(this.page, link, slackLinkUrl);
 });
 
 Then('the support form link on the main decide page will contain the correct URL', async function () {
-  let contactUsText: string = "support form"
-  let contactUsUrl: string = "/contact-us"
+    let contactUsText: string = 'support form'
+    let contactUsUrl: string = '/contact-us'
 
-  let link = await getLink(this.page,  contactUsText);
-  await checkUrl(this.page, link, contactUsUrl);
+    let link = await getLink(this.page, contactUsText);
+    await checkUrl(this.page, link, contactUsUrl);
 });
-
-

--- a/features/support/steps/documentation-steps.ts
+++ b/features/support/steps/documentation-steps.ts
@@ -1,14 +1,14 @@
-import {Then} from "@cucumber/cucumber";
-import {strict as assert} from "assert";
-import {Page} from "puppeteer";
+import { Then } from '@cucumber/cucumber';
+import { strict as assert } from 'assert';
+import { Page } from 'puppeteer';
 
 Then('the left-hand navigation menu is displayed', async function () {
     let technicalDocumentation = await this.page.$x(`//nav[@class="sub-navigation"]/ul[contains(@class, "govuk-list")]//a[@href="/documentation" and contains(text(), "Technical documentation")]`);
-    assertElementFound(technicalDocumentation, "Technical documentation");
+    assertElementFound(technicalDocumentation, 'Technical documentation');
     let userJourneyMaps = await this.page.$x(`//nav[@class="sub-navigation"]/ul[contains(@class, "govuk-list")]//a[@href="/documentation/user-journeys" and contains(text(), "User journey maps")]`);
-    assertElementFound(userJourneyMaps, "User journey maps");
+    assertElementFound(userJourneyMaps, 'User journey maps');
     let designRecommendations = await this.page.$x(`//nav[@class="sub-navigation"]/ul[contains(@class, "govuk-list")]//a[@href="/documentation/design-recommendations" and contains(text(), "Design recommendations")]`);
-    assertElementFound(designRecommendations, "Design recommendations");
+    assertElementFound(designRecommendations, 'Design recommendations');
 });
 
 function assertElementFound(element: any, description: string): void {

--- a/features/support/steps/mailing-list-steps.ts
+++ b/features/support/steps/mailing-list-steps.ts
@@ -1,47 +1,47 @@
-import {Given, Then} from "@cucumber/cucumber";
+import { Given } from '@cucumber/cucumber';
 
 Given('that the users enter alphanumeric characters into all of the fields in the mailing list form', async function () {
-  await this.goToPath("/mailing-list");
-  await this.page.type("#personalName", 'Tessa Ting');
-  await this.page.type('#organisationName', 'Department of Sorcery');
-  await this.page.type("#contactEmail", 'tessa.ting@foo-bar.gov.uk');
-  await this.page.type("#serviceName", 'Unicorn Testing');
+    await this.goToPath('/mailing-list');
+    await this.page.type('#personalName', 'Tessa Ting');
+    await this.page.type('#organisationName', 'Department of Sorcery');
+    await this.page.type('#contactEmail', 'tessa.ting@foo-bar.gov.uk');
+    await this.page.type('#serviceName', 'Unicorn Testing');
 });
 
 Given('that the users enter alphanumeric characters into all of the fields in the mailing list form except the Name field', async function () {
-  await this.goToPath("/mailing-list");
-  await this.page.type('#organisationName', 'Department of Sorcery');
-  await this.page.type("#contactEmail", 'tessa.ting@foo-bar.gov.uk');
-  await this.page.type("#serviceName", 'Unicorn Testing');
+    await this.goToPath('/mailing-list');
+    await this.page.type('#organisationName', 'Department of Sorcery');
+    await this.page.type('#contactEmail', 'tessa.ting@foo-bar.gov.uk');
+    await this.page.type('#serviceName', 'Unicorn Testing');
 });
 
 Given('that the users enter alphanumeric characters into all of the fields in the mailing list form except the Organisation name field', async function () {
-  await this.goToPath("/mailing-list");
-  await this.page.type("#personalName", 'Tessa Ting');
-  await this.page.type("#contactEmail", 'tessa.ting@foo-bar.gov.uk');
-  await this.page.type("#serviceName", 'Unicorn Testing');
+    await this.goToPath('/mailing-list');
+    await this.page.type('#personalName', 'Tessa Ting');
+    await this.page.type('#contactEmail', 'tessa.ting@foo-bar.gov.uk');
+    await this.page.type('#serviceName', 'Unicorn Testing');
 });
 
 Given('that the users enter alphanumeric characters into all of the fields in the mailing list form except the Contact email field', async function () {
-  await this.goToPath("/mailing-list");
-  await this.page.type("#personalName", 'Tessa Ting');
-  await this.page.type('#organisationName', 'Department of Sorcery');
-  await this.page.type("#serviceName", 'Unicorn Testing');
+    await this.goToPath('/mailing-list');
+    await this.page.type('#personalName', 'Tessa Ting');
+    await this.page.type('#organisationName', 'Department of Sorcery');
+    await this.page.type('#serviceName', 'Unicorn Testing');
 });
 
 Given('that the users enter alphanumeric characters into all of the fields in the mailing list form except the Service name field', async function () {
-  await this.goToPath("/mailing-list");
-  await this.page.type("#personalName", 'Tessa Ting');
-  await this.page.type('#organisationName', 'Department of Sorcery');
-  await this.page.type("#contactEmail", 'tessa.ting@foo-bar.gov.uk');
+    await this.goToPath('/mailing-list');
+    await this.page.type('#personalName', 'Tessa Ting');
+    await this.page.type('#organisationName', 'Department of Sorcery');
+    await this.page.type('#contactEmail', 'tessa.ting@foo-bar.gov.uk');
 });
 
 Given('that the user enters an invalid email address into the email field of join our mailing list form', async function () {
-  await this.goToPath("/mailing-list");
-  await this.page.type('#contactEmail', '1 Station Road, Newtown, Countyshire AB1 2CD');
+    await this.goToPath('/mailing-list');
+    await this.page.type('#contactEmail', '1 Station Road, Newtown, Countyshire AB1 2CD');
 });
 
 Given('that the user enters a non-government email address into the email field of join our mailing list form', async function () {
-  await this.goToPath("/mailing-list");
-  await this.page.type('#contactEmail', 'bill@microsoft.com');
+    await this.goToPath('/mailing-list');
+    await this.page.type('#contactEmail', 'bill@microsoft.com');
 });

--- a/features/support/steps/register-steps.ts
+++ b/features/support/steps/register-steps.ts
@@ -1,71 +1,70 @@
-import {Given, Then} from "@cucumber/cucumber";
+import { Given } from '@cucumber/cucumber';
 
 Given('that the users enter alphanumeric characters into all of the fields', async function () {
-  await this.goToPath("/register");
-  await this.page.type("#name", 'Tessa Ting');
-  await this.page.type('#organisation-name', 'Department of Sorcery');
-  await this.page.type("#email", 'tessa.ting@foo-bar.gov.uk');
-  await this.page.type("#service-name", 'Unicorn Testing');
-  await this.page.click('#mailing-list-yes');
-  
+    await this.goToPath('/register');
+    await this.page.type('#name', 'Tessa Ting');
+    await this.page.type('#organisation-name', 'Department of Sorcery');
+    await this.page.type('#email', 'tessa.ting@foo-bar.gov.uk');
+    await this.page.type('#service-name', 'Unicorn Testing');
+    await this.page.click('#mailing-list-yes');
+
 });
 
 Given('that the users enter alphanumeric characters into all of the fields in the register form except the Name field', async function () {
-  await this.goToPath("/register");
-  await this.page.type('#organisation-name', 'Department of Sorcery');
-  await this.page.type("#email", 'tessa.ting@foo-bar.gov.uk');
-  await this.page.type("#service-name", 'Unicorn Testing');
-  await this.page.click('#mailing-list-yes');
+    await this.goToPath('/register');
+    await this.page.type('#organisation-name', 'Department of Sorcery');
+    await this.page.type('#email', 'tessa.ting@foo-bar.gov.uk');
+    await this.page.type('#service-name', 'Unicorn Testing');
+    await this.page.click('#mailing-list-yes');
 });
 
 Given('that the users enter alphanumeric characters into all of the fields in the register form except the Organisation name field', async function () {
-  await this.goToPath("/register");
-  await this.page.type("#name", 'Tessa Ting');
-  await this.page.type("#email", 'tessa.ting@foo-bar.gov.uk');
-  await this.page.type("#service-name", 'Unicorn Testing');
-  await this.page.click('#mailing-list-yes');
+    await this.goToPath('/register');
+    await this.page.type('#name', 'Tessa Ting');
+    await this.page.type('#email', 'tessa.ting@foo-bar.gov.uk');
+    await this.page.type('#service-name', 'Unicorn Testing');
+    await this.page.click('#mailing-list-yes');
 });
 
 Given('that the users enter alphanumeric characters into all of the fields in the register form except the Contact email field', async function () {
-  await this.goToPath("/register");
-  await this.page.type("#name", 'Tessa Ting');
-  await this.page.type('#organisation-name', 'Department of Sorcery');
-  await this.page.type("#service-name", 'Unicorn Testing');
-  await this.page.click('#mailing-list-yes');
+    await this.goToPath('/register');
+    await this.page.type('#name', 'Tessa Ting');
+    await this.page.type('#organisation-name', 'Department of Sorcery');
+    await this.page.type('#service-name', 'Unicorn Testing');
+    await this.page.click('#mailing-list-yes');
 });
 
 Given('that the users enter alphanumeric characters into all of the fields in the register form except the Service name field', async function () {
-  await this.goToPath("/register");
-  await this.page.type("#name", 'Tessa Ting');
-  await this.page.type('#organisation-name', 'Department of Sorcery');
-  await this.page.type("#email", 'tessa.ting@foo-bar.gov.uk');
-  await this.page.click('#mailing-list-yes');
+    await this.goToPath('/register');
+    await this.page.type('#name', 'Tessa Ting');
+    await this.page.type('#organisation-name', 'Department of Sorcery');
+    await this.page.type('#email', 'tessa.ting@foo-bar.gov.uk');
+    await this.page.click('#mailing-list-yes');
 });
 
 Given('that the user enters an invalid email address into the email field', async function () {
-  await this.goToPath("/register");
-  await this.page.type('#email', '1 Station Road, Newtown, Countyshire AB1 2CD');
+    await this.goToPath('/register');
+    await this.page.type('#email', '1 Station Road, Newtown, Countyshire AB1 2CD');
 });
 
 Given('that the user enters a non-government email address into the email field', async function () {
-  await this.goToPath("/register");
-  await this.page.type('#email', 'bill@microsoft.com');
+    await this.goToPath('/register');
+    await this.page.type('#email', 'bill@microsoft.com');
 });
 
 Given('that the users enter alphanumeric characters into all of the fields in the register form except the mailing-list radio', async function () {
-    await this.goToPath("/register");
-    await this.page.type("#name", 'Tessa Ting');
+    await this.goToPath('/register');
+    await this.page.type('#name', 'Tessa Ting');
     await this.page.type('#organisation-name', 'Department of Sorcery');
-    await this.page.type("#email", 'tessa.ting@foo-bar.gov.uk');
-    await this.page.type("#service-name", 'Unicorn Testing');
-  });
-  
-  Given('that the users enter alphanumeric characters into all of the fields in the register form and select no for the mailing list', async function () {
-    await this.goToPath("/register");
-    await this.page.type("#name", 'Tessa Ting');
+    await this.page.type('#email', 'tessa.ting@foo-bar.gov.uk');
+    await this.page.type('#service-name', 'Unicorn Testing');
+});
+
+Given('that the users enter alphanumeric characters into all of the fields in the register form and select no for the mailing list', async function () {
+    await this.goToPath('/register');
+    await this.page.type('#name', 'Tessa Ting');
     await this.page.type('#organisation-name', 'Department of Sorcery');
-    await this.page.type("#email", 'tessa.ting@foo-bar.gov.uk');
-    await this.page.type("#service-name", 'Unicorn Testing');
+    await this.page.type('#email', 'tessa.ting@foo-bar.gov.uk');
+    await this.page.type('#service-name', 'Unicorn Testing');
     await this.page.click('#mailing-list-no');
-  });
-  
+});

--- a/features/support/steps/request-private-beta-steps.ts
+++ b/features/support/steps/request-private-beta-steps.ts
@@ -1,47 +1,47 @@
-import {Given} from "@cucumber/cucumber";
+import { Given } from '@cucumber/cucumber';
 
 Given('that the users enter alphanumeric characters into all of the fields in the request access to private beta form', async function () {
-    await this.goToPath("/decide/private-beta/request-form");
+    await this.goToPath('/decide/private-beta/request-form');
     await this.page.type('#email', 'tessa.ting@foo-bar.gov.uk');
-    await this.page.type("#name", 'Tessa Ting');
-    await this.page.type("#service-name", "Unicorn Testing");
-    await this.page.type("#department-name", "Department of Sorcery");
+    await this.page.type('#name', 'Tessa Ting');
+    await this.page.type('#service-name', 'Unicorn Testing');
+    await this.page.type('#department-name', 'Department of Sorcery');
 });
 
 Given('that the users enter alphanumeric characters into all of the fields in the request access to private beta form except the name field', async function () {
-    await this.goToPath("/decide/private-beta/request-form");
+    await this.goToPath('/decide/private-beta/request-form');
     await this.page.type('#email', 'tessa.ting@foo-bar.gov.uk');
-    await this.page.type("#service-name", "Unicorn Testing");
-    await this.page.type("#department-name", "Department of Sorcery");
+    await this.page.type('#service-name', 'Unicorn Testing');
+    await this.page.type('#department-name', 'Department of Sorcery');
 });
 
 Given('that the users enter alphanumeric characters into all of the fields in the request access to private beta form except the email field', async function () {
-    await this.goToPath("/decide/private-beta/request-form");
-    await this.page.type("#name", 'Tessa Ting');
-    await this.page.type("#service-name", "Unicorn Testing");
-    await this.page.type("#department-name", "Department of Sorcery");
+    await this.goToPath('/decide/private-beta/request-form');
+    await this.page.type('#name', 'Tessa Ting');
+    await this.page.type('#service-name', 'Unicorn Testing');
+    await this.page.type('#department-name', 'Department of Sorcery');
 });
 
 Given('that the users enter alphanumeric characters into all of the fields in the request access to private beta form except the department-name field', async function () {
-    await this.goToPath("/decide/private-beta/request-form");
+    await this.goToPath('/decide/private-beta/request-form');
     await this.page.type('#email', 'tessa.ting@foo-bar.gov.uk');
-    await this.page.type("#name", 'Tessa Ting');
-    await this.page.type("#service-name", "Unicorn Testing");
+    await this.page.type('#name', 'Tessa Ting');
+    await this.page.type('#service-name', 'Unicorn Testing');
 });
 
 Given('that the users enter alphanumeric characters into all of the fields in the request access to private beta form except the service-name field', async function () {
-    await this.goToPath("/decide/private-beta/request-form");
+    await this.goToPath('/decide/private-beta/request-form');
     await this.page.type('#email', 'tessa.ting@foo-bar.gov.uk');
-    await this.page.type("#name", 'Tessa Ting');
-    await this.page.type("#department-name", "Department of Sorcery");
+    await this.page.type('#name', 'Tessa Ting');
+    await this.page.type('#department-name', 'Department of Sorcery');
 });
 
 Given('that the user enters an invalid email address into the email field of the request access to private beta form', async function () {
-    await this.goToPath("/decide/private-beta/request-form");
+    await this.goToPath('/decide/private-beta/request-form');
     await this.page.type('#email', '1 Station Road, Newtown, Countyshire AB1 2CD');
 });
 
 Given('that the user enters a non-government email address into the email field of the request access to private beta form', async function () {
-    await this.goToPath("/decide/private-beta/request-form");
+    await this.goToPath('/decide/private-beta/request-form');
     await this.page.type('#email', 'bill@microsoft.com');
 });

--- a/features/support/steps/shared-functions.ts
+++ b/features/support/steps/shared-functions.ts
@@ -1,5 +1,5 @@
-import {ElementHandle, Page} from "puppeteer";
-import {strict as assert} from "assert";
+import { strict as assert } from 'assert';
+import { ElementHandle, Page } from 'puppeteer';
 
 export async function getLink(page: Page, linkText: string): Promise<any> {
     let links = await page.$x(`//a[contains(., '${linkText}')]`);
@@ -10,4 +10,3 @@ export async function getLink(page: Page, linkText: string): Promise<any> {
 export async function checkUrl(page: Page, links: ElementHandle[], expectedUrl: string): Promise<void> {
     assert.equal(await page.evaluate((anchor: { getAttribute: (arg0: string) => any; }) => anchor.getAttribute('href'), links[0]), expectedUrl);
 }
-

--- a/features/support/steps/shared-steps.ts
+++ b/features/support/steps/shared-steps.ts
@@ -29,8 +29,9 @@ When('they select the Submit button', async function () {
     ]);
 });
 
-Then('they should be directed to the following page: {string}', async function (url) {
-    assert.equal(this.page.url(), this.host + url);
+Then('they should be directed to the following page: {string}', async function (path) {
+    const expectedUrl = new URL(path, this.host);
+    assert.equal(this.page.url(), expectedUrl.href);
 });
 
 Then('they should be directed to the following URL: {string}', async function (url) {
@@ -48,26 +49,12 @@ Then('their data is saved in the spreadsheet', async function () {
 
 Then('the error message {string} must be displayed for the {string} field', async function (errorMessage, field) {
     const errorLink = await this.page.$x(`//div[contains(concat(" ", normalize-space(@class), " "), " govuk-error-summary ")]//a[@href="#${field}"]`);
-    assert.notEqual(errorLink.length, 0, `Expected to find the message ${errorMessage} in the error summary.`);
-    const actualMessageInSummary = await this.page.evaluate((el: { textContent: any; }) => el.textContent, errorLink[0]);
-    assert.equal(actualMessageInSummary, errorMessage, `Expected text of the link to be ${errorMessage}`);
-
-    const messageAboveElement = await this.page.$x(`//span[contains(concat(" ", normalize-space(@class), " "), " govuk-error-message ") and @id="${field}-error" ]`);
-    assert.notEqual(messageAboveElement.length, 0, `Expected to find the message ${errorMessage} above the ${field} field.`);
-    const actualMessageAboveSummary = await this.page.evaluate((el: { textContent: any; }) => el.textContent, messageAboveElement[0]);
-    assert.equal(actualMessageAboveSummary.trim(), "Error: " + errorMessage, `Expected the message above the ${field} field to be ${errorMessage}`);
+    await checkErrorMessageDisplayedAboveElement(this.page, errorLink, errorMessage, field);
 });
 
 Then('the error message {string} must be displayed for the {string} radios', async function (errorMessage, field) {
     const errorLink = await this.page.$x(`//div[contains(concat(" ", normalize-space(@class), " "), " govuk-error-summary ")]//a[@href="#${field}-error"]`);
-    assert.notEqual(errorLink.length, 0, `Expected to find the message ${errorMessage} in the error summary.`);
-    const actualMessageInSummary = await this.page.evaluate((el: { textContent: any; }) => el.textContent, errorLink[0]);
-    assert.equal(actualMessageInSummary, errorMessage, `Expected text of the link to be ${errorMessage}`);
-
-    const messageAboveElement = await this.page.$x(`//span[contains(concat(" ", normalize-space(@class), " "), " govuk-error-message ") and @id="${field}-error" ]`);
-    assert.notEqual(messageAboveElement.length, 0, `Expected to find the message ${errorMessage} above the ${field} field.`);
-    const actualMessageAboveSummary = await this.page.evaluate((el: { textContent: any; }) => el.textContent, messageAboveElement[0]);
-    assert.equal(actualMessageAboveSummary.trim(), "Error: " + errorMessage, `Expected the message above the ${field} field to be ${errorMessage}`);
+    await checkErrorMessageDisplayedAboveElement(this.page, errorLink, errorMessage, field);
 });
 
 Then('they should see the text {string}', async function (text) {
@@ -84,3 +71,16 @@ Then('the {string} link will point to the following page: {string}', async funct
     let link = await getLink(this.page, linkText);
     await checkUrl(this.page, link, expectedPage);
 });
+
+async function checkErrorMessageDisplayedAboveElement(page: Page, errorLink: any, errorMessage: string, field: string) {
+    assert.notEqual(errorLink.length, 0, `Expected to find the message ${errorMessage} in the error summary.`);
+
+    const actualMessageInSummary = await page.evaluate((el: { textContent: any; }) => el.textContent, errorLink[0]);
+    assert.equal(actualMessageInSummary, errorMessage, `Expected text of the link to be ${errorMessage}`);
+
+    const messageAboveElement = await page.$x(`//span[contains(concat(" ", normalize-space(@class), " "), " govuk-error-message ") and @id="${field}-error" ]`);
+    assert.notEqual(messageAboveElement.length, 0, `Expected to find the message ${errorMessage} above the ${field} field.`);
+
+    const actualMessageAboveSummary = await page.evaluate((el: { textContent: any; }) => el.textContent, messageAboveElement[0]);
+    assert.equal(actualMessageAboveSummary.trim(), `Error: ${errorMessage}`, `Expected the message above the ${field} field to be ${errorMessage}`);
+}

--- a/features/support/steps/shared-steps.ts
+++ b/features/support/steps/shared-steps.ts
@@ -1,6 +1,7 @@
-import {Given, When, Then} from "@cucumber/cucumber";
-import {strict as assert} from "assert";
-import {getLink, checkUrl} from './shared-functions';
+import { Given, Then, When } from '@cucumber/cucumber';
+import { strict as assert } from 'assert';
+import { Page } from 'puppeteer';
+import { checkUrl, getLink } from './shared-functions';
 
 Given('that the user is on the {string} page', async function (route: string) {
     await this.goToPath(route);
@@ -9,7 +10,7 @@ Given('that the user is on the {string} page', async function (route: string) {
 When('they click on the {string} link', async function (text: string) {
     let links = await this.page.$x(`//a[contains(., '${text}')]`);
     await Promise.all([
-        this.page.waitForNavigation({timeout: 10000}),
+        this.page.waitForNavigation({ timeout: 10000 }),
         links[0].click()
     ]);
 });
@@ -17,7 +18,7 @@ When('they click on the {string} link', async function (text: string) {
 When('they click on the {string} button-link', async function (text: string) {
     let links = await this.page.$x(`//a[contains(., '${text}') and contains(concat(" ", normalize-space(@class), " "), " govuk-button ")]`);
     await Promise.all([
-        this.page.waitForNavigation({timeout: 10000}),
+        this.page.waitForNavigation({ timeout: 10000 }),
         links[0].click()
     ]);
 });
@@ -25,7 +26,7 @@ When('they click on the {string} button-link', async function (text: string) {
 When('they select the Submit button', async function () {
     await Promise.all([
         this.page.waitForNavigation(),
-        this.page.click("#submit")
+        this.page.click('#submit')
     ]);
 });
 

--- a/features/support/steps/support-steps.ts
+++ b/features/support/steps/support-steps.ts
@@ -1,4 +1,4 @@
-import {When} from "@cucumber/cucumber";
+import { When } from '@cucumber/cucumber';
 
 When('they select the {string} button', async function (id) {
     await Promise.all([

--- a/features/support/steps/user-journeys-steps.ts
+++ b/features/support/steps/user-journeys-steps.ts
@@ -1,5 +1,5 @@
-import {Given, Then} from "@cucumber/cucumber";
-import {strict as assert} from "assert";
+import { Given, Then } from '@cucumber/cucumber';
+import { strict as assert } from 'assert';
 
 Given('the user wants to contact the service', async function () {
     // just here for the story to read better

--- a/features/support/test-setup.ts
+++ b/features/support/test-setup.ts
@@ -1,9 +1,9 @@
-import {Browser} from "puppeteer";
-import {After, AfterAll, Before, BeforeAll} from "@cucumber/cucumber";
-import {IWorldOptions} from "@cucumber/cucumber/lib/support_code_library_builder/world";
+import { After, AfterAll, Before, BeforeAll } from '@cucumber/cucumber';
+import { IWorldOptions } from '@cucumber/cucumber/lib/support_code_library_builder/world';
+import { Browser } from 'puppeteer';
 
 const puppeteer = require('puppeteer');
-const {setWorldConstructor, World} = require("@cucumber/cucumber");
+const { setWorldConstructor, World } = require('@cucumber/cucumber');
 
 let browser: Browser;
 
@@ -18,8 +18,8 @@ class TestContext extends World {
 }
 
 BeforeAll(async function () {
-    console.log(`Running tests against ${process.env.HOST || "local"}`)
-    browser = await puppeteer.launch({headless: true});
+    console.log(`Running tests against ${process.env.HOST || 'local'}`)
+    browser = await puppeteer.launch({ headless: true });
 })
 
 Before(async function () {


### PR DESCRIPTION
- Correctly construct URLs in feature tests 

Avoid failing tests due to double slashes caused by directly adding two strings. Use the URL class instead to handle URL construction.

---

_Formatting changes in a separate commit_

- Apply formatting
- Optimise imports
- Use one kind of quotes for strings (single quotes)
- Remove duplicated code fragments by moving the repeated blocks into functions.

