### PR TITLE
BAU: Enable `noUnusedLocals` and optimise JavaScripts

### DIFF
--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -1,5 +1,0 @@
-import BackToTop from './back-to-top.js'
-
-// Initialise back to top
-var $backToTop = document.querySelector('[data-module="app-back-to-top"]')
-new BackToTop($backToTop).init()

--- a/assets/javascripts/back-to-top.js
+++ b/assets/javascripts/back-to-top.js
@@ -66,4 +66,4 @@ BackToTop.prototype.init = function () {
     observer.observe($subNav)
 }
 
-export default BackToTop
+new BackToTop(document.querySelector('[data-module="app-back-to-top"]')).init()

--- a/assets/javascripts/cookies.js
+++ b/assets/javascripts/cookies.js
@@ -147,8 +147,7 @@ var cookieBanner = function () {
     }
 
     function initGATagManager(hasGivenConsent) {
-        if (hasGivenConsent) {
-
+        if (hasGivenConsent && gaTrackingCode['value']) {
             const commentStart = document.createComment(' Google Tag Manager ')
             document.head.append(commentStart);
 

--- a/assets/javascripts/cookies.js
+++ b/assets/javascripts/cookies.js
@@ -198,6 +198,6 @@ var cookieBanner = function () {
 };
 
 if (window) {
-    window.GOVSignin = window.GOVSignin || {};
-    window.GOVSignin.CookieBanner = cookieBanner();
+    window.GOVUKSignIn = window.GOVUKSignIn || {};
+    window.GOVUKSignIn.CookieBanner = cookieBanner();
 }

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,12 @@
+{
+  "restartable": "rs",
+  "ignore": [".git", "node_modules/", "dist/", "coverage/"],
+  "watch": ["src/"],
+  "execMap": {
+    "ts": "node -r ts-node/register"
+  },
+  "env": {
+    "NODE_ENV": "development"
+  },
+  "ext": "js,json,ts,njk"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@googleapis/sheets": "^0.3.0",
         "axios": "^0.27.2",
-        "dotenv": "^16.0.1",
         "email-validator": "^2.0.4",
         "express": "^4.18.1",
         "google-auth-library": "^8.1.1",
@@ -32,6 +31,7 @@
         "@types/puppeteer": "^5.4.6",
         "@types/uuid": "^8.3.4",
         "chai": "^4.3.6",
+        "dotenv": "^16.0.1",
         "mocha": "^10.0.0",
         "node-sass": "^7.0.1",
         "nodemon": "^2.0.19",
@@ -2106,6 +2106,7 @@
       "version": "16.0.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
       "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -10057,7 +10058,8 @@
     "dotenv": {
       "version": "16.0.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
-      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ=="
+      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
+      "dev": true
     },
     "duration": {
       "version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "@googleapis/sheets": "^0.3.0",
     "axios": "^0.27.2",
-    "dotenv": "^16.0.1",
     "express": "^4.18.1",
     "google-auth-library": "^8.1.1",
     "googleapis": "^91.0.0",
@@ -43,6 +42,7 @@
     "@types/nunjucks": "^3.2.1",
     "@types/puppeteer": "^5.4.6",
     "@types/uuid": "^8.3.4",
+    "dotenv": "^16.0.1",
     "chai": "^4.3.6",
     "mocha": "^10.0.0",
     "node-sass": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "nodemon -r 'dotenv/config' src/app.ts",
     "buildts": "tsc -p .",
     "buildsass": "node-sass --importer node_modules/node-sass-package-importer/dist/cli.js assets/css/app.scss dist/assets/app.css",
-    "buildjs": "uglifyjs --verbose node_modules/govuk-frontend/govuk/all.js -o dist/assets/govuk-all.js && uglifyjs --verbose assets/javascripts/cookies.js -o dist/assets/cookies.js && cp -v -r assets/javascripts/application.js ./dist/assets/application.js  && cp -v -r assets/javascripts/back-to-top.js ./dist/assets/back-to-top.js  && cp -v -r node_modules/govuk-frontend/govuk/vendor/polyfills/Function/prototype/bind.js ./dist/assets/bind.js",
+    "buildjs": "uglifyjs --verbose node_modules/govuk-frontend/govuk/all.js -o dist/assets/govuk-all.js && uglifyjs --verbose assets/javascripts/cookies.js -o dist/assets/cookies.js && cp -vr assets/javascripts/back-to-top.js ./dist/assets/back-to-top.js && cp -vr node_modules/govuk-frontend/govuk/vendor/polyfills/Function/prototype/bind.js ./dist/assets/bind.js",
     "buildgovuk": "cp -v -r node_modules/govuk-frontend/govuk/assets/* ./dist/assets && echo \"Done!\"",
     "buildlocalimages": "cp -v -r assets/images/* ./dist/assets/images",
     "buildlocalfiles": "mkdirp ./dist/routes/files && cp -v -r files/* ./dist/routes/files",

--- a/src/controllers/mailing-list.ts
+++ b/src/controllers/mailing-list.ts
@@ -1,7 +1,7 @@
-import express, {NextFunction, Request, Response} from 'express';
-import SheetsService from "../lib/sheets/SheetsService";
 import * as EmailValidator from 'email-validator';
+import {Request, Response} from 'express';
 import {promises as fs} from 'fs';
+import SheetsService from "../lib/sheets/SheetsService";
 
 export const mailingList = async function(req: Request, res: Response) {
   const personalName = req.body.personalName;

--- a/src/lib/zendesk/ZendeskService.ts
+++ b/src/lib/zendesk/ZendeskService.ts
@@ -1,11 +1,12 @@
 import ZendeskInterface from "./interface";
 
 export default class SheetsService implements ZendeskInterface {
+    private readonly username: string;
+    private readonly apiToken: string;
+    private readonly tag: string;
+    private readonly groupId: string;
+
     private implementation!: ZendeskInterface;
-    private username: string;
-    private apiToken: string;
-    private tag: string;
-    private groupId: string;
 
     constructor(username: string, apiToken: string, tag: string, groupId: string) {
         this.username = username;
@@ -28,7 +29,7 @@ export default class SheetsService implements ZendeskInterface {
         this.implementation = new service(this.username, this.apiToken, this.tag, this.groupId);
     }
 
-    async submit(form:  Map<string, string>): Promise<any> {
+    async submit(form: Map<string, string>): Promise<any> {
         return this.implementation.submit(form);
     }
 }

--- a/src/lib/zendesk/interface.ts
+++ b/src/lib/zendesk/interface.ts
@@ -1,3 +1,3 @@
 export default interface ZendeskInterface {
-    submit(form:  Map<string, string>): Promise<boolean>
+    submit(form: Map<string, string>): Promise<boolean>
 }

--- a/src/lib/zendesk/stubZendesk/stubZendeskService.ts
+++ b/src/lib/zendesk/stubZendesk/stubZendeskService.ts
@@ -1,18 +1,7 @@
 import ZendeskInterface from "../interface";
 
 export default class StubZendeskService implements ZendeskInterface {
-    private email: string;
-    private apiToken: string;
-    private tag: string;
-
-    constructor(email: string, apiToken: string, tag: string) {
-        this.email = email;
-        this.apiToken = apiToken;
-        this.tag = tag;
-    }
-
-
-    submit(form:  Map<string, string>): Promise<boolean> {
+    submit(form: Map<string, string>): Promise<boolean> {
         return Promise.resolve(true);
     }
 }

--- a/src/views/base-evaluate.njk
+++ b/src/views/base-evaluate.njk
@@ -14,7 +14,6 @@
 {% endblock %}
 
 {% block bodyStart %}
-
   <div class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Cookies on GOV.UK Sign In" style="display: none">
     <div class="govuk-cookie-banner__message govuk-width-container" id="cookies-banner-main">
 
@@ -75,7 +74,6 @@
       </div>
     </div>
   </div>
-
 {% endblock %}
 
 {% block header %}
@@ -101,8 +99,6 @@
       </div>
     </div>
   </header>
-
-
 {% endblock %}
 
 {% block main %}
@@ -154,13 +150,11 @@
   </footer>
 {% endblock %}
 
-
-
 {% block bodyEnd %}
   <input type="hidden" value="{{ googleTagId }}" id="ga-tracking">
   {# Run JavaScript at end of the <body>, to avoid blocking the initial render. #}
   <script src="/dist/govuk-all.js"></script>
   <script src="/dist/cookies.js"></script>
   <script>window.GOVUKFrontend.initAll()</script>
-  <script>window.GOVSignin.CookieBanner.init()</script>
+  <script>window.GOVUKSignIn.CookieBanner.init()</script>
 {% endblock %}

--- a/src/views/base.njk
+++ b/src/views/base.njk
@@ -14,7 +14,6 @@
 {% endblock %}
 
 {% block bodyStart %}
-
   <div class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Cookies on GOV.UK Sign In" style="display: none">
     <div class="govuk-cookie-banner__message govuk-width-container" id="cookies-banner-main">
 
@@ -181,14 +180,13 @@
   </footer>
 {% endblock %}
 
-
-
 {% block bodyEnd %}
   <input type="hidden" value="{{ googleTagId }}" id="ga-tracking">
   {# Run JavaScript at end of the <body>, to avoid blocking the initial render. #}
   <script src="/dist/govuk-all.js"></script>
   <script src="/dist/cookies.js"></script>
-  <script type="module" src="/dist/application.js"></script>
   <script>window.GOVUKFrontend.initAll()</script>
-  <script>window.GOVSignin.CookieBanner.init()</script>
+  <script>window.GOVUKSignIn.CookieBanner.init()</script>
+
+  {% block scripts %}{% endblock %}
 {% endblock %}

--- a/src/views/documentation-design-recommendations.njk
+++ b/src/views/documentation-design-recommendations.njk
@@ -27,7 +27,6 @@
 {% endblock %}
 
 {% block content %}
-
   <div class="govuk-width-container">
     <div class="govuk-grid-row" style="position: relative;">
 
@@ -135,7 +134,8 @@
       </div>
     </div>
   </div>
-
 {% endblock %}
 
-
+{% block scripts %}
+  <script type="module" src="/dist/back-to-top.js"></script>
+{% endblock %}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,7 +35,7 @@
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 
     /* Additional Checks */
-    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    "noUnusedLocals": true,                /* Report errors on unused locals. */
     // "noUnusedParameters": true,            /* Report errors on unused parameters. */
     // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */


### PR DESCRIPTION
- Enable the noUnusedLocals flag in tsconfig.json 
Remove unused locals to let the build succeed

- Move dotenv to devDependencies
-  Only load the back-top-script when it's needed
-  Only initialise the Google Tag Manager if the tag value is provided 

- Add nodemon config to allow it to automatically restart the app for local development