### PR TITLE
BAU: Use macros and govuk components

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -164,7 +164,7 @@ div.feature-panel {
   #main-content.side-nav-wrapper .govuk-grid-column-one-third  {
     width: 25%;
   }
-  #main-content.side-nav-wrapper.govuk-main-wrapper-documentation .govuk-grid-column-one-third  {
+  #main-content.side-nav-wrapper.documentation-wrapper .govuk-grid-column-one-third  {
     width: 32%;
   }
 }

--- a/src/controllers/mailing-list.ts
+++ b/src/controllers/mailing-list.ts
@@ -14,7 +14,7 @@ export const mailingList = async function(req: Request, res: Response) {
     personalNameHolder: personalName,
     organisationNameHolder: organisationName,
     contactEmailHolder: contactEmail,
-    serviceNamehHolder: serviceName
+    serviceNameHolder: serviceName
   }
 
   const onlyLettersPattern = /^[a-zA-Z\-\s]{1,300}$/;

--- a/src/views/accessibility.njk
+++ b/src/views/accessibility.njk
@@ -1,22 +1,8 @@
 {% extends "base.njk" %}
+{% from "macros/breadcrumbs.njk" import breadcrumbs %}
 
 {% set pageTitle = "Accessibility statement" %}
-
-{% block beforeContent %}
-  <div class="govuk-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#gov-uk-services">GOV.UK services</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="/">GOV.UK Sign In</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="#main-content" aria-current="page">Accessibility statement</a>
-      </li>
-    </ol>
-  </div>
-{% endblock %}
+{% set breadcrumbs = breadcrumbs(currentPageName = pageTitle) %}
 
 {% block mainContent %}
   <h1 class="govuk-heading-l">

--- a/src/views/base-side-nav.njk
+++ b/src/views/base-side-nav.njk
@@ -1,3 +1,3 @@
 {% extends "base.njk" %}
 
-{% set baseClasses = "side-nav-wrapper govuk-!-padding-top-6" %}
+{% set mainClasses = ["side-nav-wrapper", mainClasses] | join(" ") %}

--- a/src/views/base.njk
+++ b/src/views/base.njk
@@ -7,7 +7,7 @@
 {% set documentationUrl = "/documentation" %}
 
 {% set showTopNav = showTopNav | default(true) %}
-{% set mainClasses = ["govuk-main-wrapper--auto-spacing", baseClasses | default("govuk-!-padding-top-7"), mainClasses | default("")] | join(" ") %}
+{% set mainClasses = ["govuk-main-wrapper--auto-spacing", baseClasses | default("govuk-!-padding-top-6"), mainClasses | default("")] | join(" ") %}
 
 {% block pageTitle %}{{ pageTitle }} - GOV.UK Sign In{% endblock %}
 

--- a/src/views/base.njk
+++ b/src/views/base.njk
@@ -144,6 +144,7 @@
 {% endblock %}
 
 {% block beforeContent %}
+  {{ backLink | safe }}
   {{ breadcrumbs | safe }}
   {% block beforeMainContent %}{% endblock %}
 {% endblock %}

--- a/src/views/base.njk
+++ b/src/views/base.njk
@@ -143,6 +143,11 @@
   </div>
 {% endblock %}
 
+{% block beforeContent %}
+  {{ breadcrumbs | safe }}
+  {% block beforeMainContent %}{% endblock %}
+{% endblock %}
+
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/src/views/contact-us-details.njk
+++ b/src/views/contact-us-details.njk
@@ -1,10 +1,8 @@
 {% extends "base.njk" %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set pageTitle = "Contact us to get started" %}
-
-{% block beforeContent %}
-  <a href="/support" class="govuk-back-link">Back</a>
-{% endblock %}
+{% set backLink = govukBackLink({text: "Back", href: "/support"}) %}
 
 {% block mainContent %}
   <h1 class="govuk-heading-l">

--- a/src/views/cookies.njk
+++ b/src/views/cookies.njk
@@ -1,22 +1,8 @@
 {% extends "base.njk" %}
+{% from "macros/breadcrumbs.njk" import breadcrumbs %}
 
 {% set pageTitle = "Cookies" %}
-
-{% block beforeContent %}
-  <div class="govuk-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#gov-uk-services">GOV.UK services</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="/">GOV.UK Sign In</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="#main-content" aria-current="page">Cookies</a>
-      </li>
-    </ol>
-  </div>
-{% endblock %}
+{% set breadcrumbs = breadcrumbs(currentPageName = pageTitle) %}
 
 {% block mainContent %}
     <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" id="save-success-banner" hidden="true">

--- a/src/views/documentation-design-recommendations.njk
+++ b/src/views/documentation-design-recommendations.njk
@@ -3,7 +3,7 @@
 
 {% set pageTitle = "Design recommendations" %}
 {% set headerNavigationActiveItem = "documentation" %}
-{% set mainClasses = "govuk-main-wrapper-documentation documentation-design-recommendations" %}
+{% set mainClasses = "documentation-wrapper documentation-design-recommendations" %}
 {% set breadcrumbs = breadcrumbs([{text: "Documentation", href: "/documentation"}], pageTitle) %}
 
 {% block content %}

--- a/src/views/documentation-design-recommendations.njk
+++ b/src/views/documentation-design-recommendations.njk
@@ -1,27 +1,10 @@
 {% extends "base-side-nav.njk" %}
+{% from "macros/breadcrumbs.njk" import breadcrumbs %}
 
 {% set pageTitle = "Design recommendations" %}
 {% set headerNavigationActiveItem = "documentation" %}
 {% set mainClasses = "govuk-main-wrapper-documentation documentation-design-recommendations" %}
-
-{% block beforeContent %}
-  <div class="govuk-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#gov-uk-services">GOV.UK services</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="/">GOV.UK Sign In</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="/documentation">Documentation</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="#main-content" aria-current="page">Design recommendations</a>
-      </li>
-    </ol>
-  </div>
-{% endblock %}
+{% set breadcrumbs = breadcrumbs([{text: "Documentation", href: "/documentation"}], pageTitle) %}
 
 {% block content %}
   <div class="govuk-grid-row" style="position: relative;">

--- a/src/views/documentation-user-journeys.njk
+++ b/src/views/documentation-user-journeys.njk
@@ -1,27 +1,10 @@
 {% extends "base-side-nav.njk" %}
+{% from "macros/breadcrumbs.njk" import breadcrumbs %}
 
 {% set pageTitle = "User journey maps" %}
 {% set mainClasses = "govuk-main-wrapper-documentation" %}
 {% set headerNavigationActiveItem = "documentation" %}
-
-{% block beforeContent %}
-  <div class="govuk-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#gov-uk-services">GOV.UK services</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="/">GOV.UK Sign In</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="/documentation">Documentation</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="#main-content" aria-current="page">User journey maps</a>
-      </li>
-    </ol>
-  </div>
-{% endblock %}
+{% set breadcrumbs = breadcrumbs([{text: "Documentation", href: "/documentation"}], pageTitle) %}
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/src/views/documentation-user-journeys.njk
+++ b/src/views/documentation-user-journeys.njk
@@ -2,7 +2,7 @@
 {% from "macros/breadcrumbs.njk" import breadcrumbs %}
 
 {% set pageTitle = "User journey maps" %}
-{% set mainClasses = "govuk-main-wrapper-documentation" %}
+{% set mainClasses = "documentation-wrapper" %}
 {% set headerNavigationActiveItem = "documentation" %}
 {% set breadcrumbs = breadcrumbs([{text: "Documentation", href: "/documentation"}], pageTitle) %}
 

--- a/src/views/documentation.njk
+++ b/src/views/documentation.njk
@@ -2,7 +2,7 @@
 {% from "macros/breadcrumbs.njk" import breadcrumbs %}
 
 {% set pageTitle = "Technical documentation" %}
-{% set mainClasses = "govuk-main-wrapper-documentation" %}
+{% set mainClasses = "documentation-wrapper" %}
 {% set headerNavigationActiveItem = "documentation" %}
 {% set breadcrumbs = breadcrumbs(currentPageName = "Documentation") %}
 

--- a/src/views/documentation.njk
+++ b/src/views/documentation.njk
@@ -1,24 +1,10 @@
 {% extends "base-side-nav.njk" %}
+{% from "macros/breadcrumbs.njk" import breadcrumbs %}
 
 {% set pageTitle = "Technical documentation" %}
 {% set mainClasses = "govuk-main-wrapper-documentation" %}
 {% set headerNavigationActiveItem = "documentation" %}
-
-{% block beforeContent %}
-  <div class="govuk-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#gov-uk-services">GOV.UK services</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="/">GOV.UK Sign In</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="#main-content" aria-current="page">Documentation</a>
-      </li>
-    </ol>
-  </div>
-{% endblock %}
+{% set breadcrumbs = breadcrumbs(currentPageName = "Documentation") %}
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/src/views/features.njk
+++ b/src/views/features.njk
@@ -1,23 +1,9 @@
 {% extends "base-side-nav.njk" %}
+{% from "macros/breadcrumbs.njk" import breadcrumbs %}
 
 {% set pageTitle = "Features" %}
 {% set headerNavigationActiveItem = "features" %}
-
-{% block beforeContent %}
-  <div class="govuk-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#gov-uk-services">GOV.UK services</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="/">GOV.UK Sign In</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="#main-content" aria-current="page">Features</a>
-      </li>
-    </ol>
-  </div>
-{% endblock %}
+{% set breadcrumbs = breadcrumbs(currentPageName = pageTitle) %}
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/src/views/getting-started-private-beta.njk
+++ b/src/views/getting-started-private-beta.njk
@@ -1,26 +1,9 @@
 {% extends "base.njk" %}
+{% from "macros/breadcrumbs.njk" import breadcrumbs %}
 
 {% set pageTitle = "Private beta" %}
 {% set headerNavigationActiveItem = "get-started" %}
-
-{% block beforeContent %}
-  <div class="govuk-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#gov-uk-services">GOV.UK services</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="/">GOV.UK Sign In</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link"  href="/getting-started" aria-current="page">Get started</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link"  href="#" aria-current="page">Private beta</a>
-      </li>
-    </ol>
-  </div>
-{% endblock %}
+{% set breadcrumbs = breadcrumbs([{text: "Get started", href: "/getting-started"}], pageTitle) %}
 
 {% block mainContent %}
   <h1 class="govuk-heading-l">Find out more about private beta</h1>

--- a/src/views/getting-started.njk
+++ b/src/views/getting-started.njk
@@ -1,25 +1,11 @@
 {% extends "base.njk" %}
+{% from "macros/breadcrumbs.njk" import breadcrumbs %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set pageTitle = "Get started" %}
 {% set baseClasses = "govuk-!-padding-top-4" %}
 {% set headerNavigationActiveItem = "get-started" %}
-
-{% block beforeContent %}
-  <div class="govuk-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#gov-uk-services">GOV.UK services</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="/">GOV.UK Sign In</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="#main-content" aria-current="page">Get started</a>
-      </li>
-    </ol>
-  </div>
-{% endblock %}
+{% set breadcrumbs = breadcrumbs(currentPageName = pageTitle) %}
 
 {% block mainContent %}
   <h1 class="govuk-heading-l">Get started</h1>

--- a/src/views/getting-started.njk
+++ b/src/views/getting-started.njk
@@ -3,7 +3,6 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set pageTitle = "Get started" %}
-{% set baseClasses = "govuk-!-padding-top-4" %}
 {% set headerNavigationActiveItem = "get-started" %}
 {% set breadcrumbs = breadcrumbs(currentPageName = pageTitle) %}
 

--- a/src/views/index.njk
+++ b/src/views/index.njk
@@ -7,13 +7,13 @@
 {% set baseClasses = "product-home-page" %}
 
 {% block main %}
-  {{ beforeContent | safe }}
+  {{ breadcrumbs | safe }}
   <main class="{{ mainClasses }}" id="main-content" role="main"{% if mainLang %} lang="{{ mainLang }}"{% endif %}>
     {{ content | safe }}
   </main>
 {% endblock %}
 
-{% set beforeContent %}
+{% set breadcrumbs %}
   <div class="hero-breadcrumb-banner">
     <div class="hero hero--breaded">
       <div class="govuk-breadcrumbs breadcrumbs-hero">

--- a/src/views/macros/breadcrumbs.njk
+++ b/src/views/macros/breadcrumbs.njk
@@ -1,0 +1,30 @@
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+
+{% macro breadcrumbs(intermediateCrumbs, currentPageName) %}
+  {% set crumbs = [
+    {
+      text: "GOV.UK services",
+      href: "https://www.gov.uk/service-toolkit#gov-uk-services"
+    },
+    {
+      text: "GOV.UK Sign In",
+      href: "/"
+    }
+  ] %}
+
+  {% for crumb in intermediateCrumbs %}
+    {% set crumbs = (crumbs.push(crumb), crumbs) %}
+  {% endfor %}
+
+  {% set crumbs = (crumbs.push({
+    text: currentPageName,
+    href: "#main-content",
+    attributes: {
+      "aria-current": "page"
+    }
+  }), crumbs) %}
+
+  {{ govukBreadcrumbs({
+    items: crumbs
+  }) }}
+{% endmacro %}

--- a/src/views/mailing-list-confirmation.njk
+++ b/src/views/mailing-list-confirmation.njk
@@ -2,7 +2,6 @@
 {% from "macros/breadcrumbs.njk" import breadcrumbs %}
 
 {% set pageTitle = "Mailing list confirmation" %}
-{% set baseClasses = "govuk-!-padding-top-3 govuk-!-margin-bottom-1" %}
 {% set breadcrumbs = breadcrumbs(currentPageName = "Join our mailing list") %}
 
 {% block mainContent %}

--- a/src/views/mailing-list-confirmation.njk
+++ b/src/views/mailing-list-confirmation.njk
@@ -1,23 +1,9 @@
 {% extends "base.njk" %}
+{% from "macros/breadcrumbs.njk" import breadcrumbs %}
 
 {% set pageTitle = "Mailing list confirmation" %}
 {% set baseClasses = "govuk-!-padding-top-3 govuk-!-margin-bottom-1" %}
-
-{% block beforeContent %}
-  <div class="govuk-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#gov-uk-services">GOV.UK services</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="/">GOV.UK Sign In</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="#main-content" aria-current="page">Join our mailing list</a>
-      </li>
-    </ol>
-  </div>
-{% endblock %}
+{% set breadcrumbs = breadcrumbs(currentPageName = "Join our mailing list") %}
 
 {% block mainContent %}
   <div class="govuk-panel govuk-panel--confirmation">

--- a/src/views/mailing-list.njk
+++ b/src/views/mailing-list.njk
@@ -6,7 +6,6 @@
 
 {% set pageTitle = "Join our mailing list" %}
 {% set breadcrumbs = breadcrumbs(currentPageName = pageTitle) %}
-{% set baseClasses = "govuk-!-padding-top-5 govuk-!-margin-bottom-0" %}
 
 {% block mainContent %}
   {{ errorSummary ({

--- a/src/views/mailing-list.njk
+++ b/src/views/mailing-list.njk
@@ -1,26 +1,12 @@
 {% extends "base.njk" %}
-{% from "./macros/error-summary.njk" import errorSummary %}
+{% from "macros/breadcrumbs.njk" import breadcrumbs %}
+{% from "macros/error-summary.njk" import errorSummary %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set pageTitle = "Join our mailing list" %}
+{% set breadcrumbs = breadcrumbs(currentPageName = pageTitle) %}
 {% set baseClasses = "govuk-!-padding-top-5 govuk-!-margin-bottom-0" %}
-
-{% block beforeContent %}
-  <div class="govuk-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#gov-uk-services">GOV.UK services</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="/">GOV.UK Sign In</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="#main-content" aria-current="page">Join our mailing list</a>
-      </li>
-    </ol>
-  </div>
-{% endblock %}
 
 {% block mainContent %}
   {{ errorSummary ({
@@ -86,7 +72,7 @@
       name: "serviceName",
       id: "serviceName",
       classes: "govuk-input--width-30",
-      value: values.serviceNamehHolder,
+      value: values.serviceNameHolder,
       errorMessage: {
         text: errors.get('serviceName')
       } if errors and errors.has('serviceName')

--- a/src/views/privacy-policy.njk
+++ b/src/views/privacy-policy.njk
@@ -1,22 +1,8 @@
 {% extends "base.njk" %}
+{% from "macros/breadcrumbs.njk" import breadcrumbs %}
 
 {% set pageTitle = "Privacy policy" %}
-
-{% block beforeContent %}
-  <div class="govuk-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#gov-uk-services">GOV.UK services</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="/">GOV.UK Sign In</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="#main-content" aria-current="page">Privacy notice</a>
-      </li>
-    </ol>
-  </div>
-{% endblock %}
+{% set breadcrumbs = breadcrumbs(currentPageName = "Privacy notice") %}
 
 {% block mainContent %}
   <h1 class="govuk-heading-l">Privacy notice</h1>

--- a/src/views/register-confirm.njk
+++ b/src/views/register-confirm.njk
@@ -1,25 +1,8 @@
 {% extends "base.njk" %}
+{% from "macros/breadcrumbs.njk" import breadcrumbs %}
 
 {% set pageTitle = "You have registered your interest" %}
-
-{% block beforeContent %}
-  <div class="govuk-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#gov-uk-services">GOV.UK services</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="/">GOV.UK Sign In</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="/getting-started">Get started</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item" aria-current="page">
-        <a class="govuk-breadcrumbs__link" href="/register" aria-current="page">Sign up to get access</a>
-      </li>
-    </ol>
-  </div>
-{% endblock %}
+{% set breadcrumbs = breadcrumbs([{text: "Get started", href: "/getting-started"}], "Sign up to get access") %}
 
 {% block mainContent %}
   <div class="govuk-panel govuk-panel--confirmation">

--- a/src/views/register-error.njk
+++ b/src/views/register-error.njk
@@ -1,25 +1,8 @@
 {% extends "base.njk" %}
+{% from "macros/breadcrumbs.njk" import breadcrumbs %}
 
 {% set pageTitle = "There is a problem registering your interest" %}
-
-{% block beforeContent %}
-  <div class="govuk-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#gov-uk-services">GOV.UK services</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="/">GOV.UK Sign In</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="/register">Register your Interest</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item" aria-current="page">
-        <a class="govuk-breadcrumbs__link" href="#main-content" aria-current="page">Error</a>
-      </li>
-    </ol>
-  </div>
-{% endblock %}
+{% set breadcrumbs = breadcrumbs([{text: "Register your Interest", href: "/register"}], "Error") %}
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/src/views/register.njk
+++ b/src/views/register.njk
@@ -1,26 +1,8 @@
 {% extends "base.njk" %}
+{% from "macros/breadcrumbs.njk" import breadcrumbs %}
 
 {% set pageTitle = "Sign up to get access" %}
-
-{% block beforeContent %}
-  <div class="govuk-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#gov-uk-services">GOV.UK
-          services</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="/">GOV.UK Sign In</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="/getting-started">Get started</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="#main-content" aria-current="page">Sign up to get access</a>
-      </li>
-    </ol>
-  </div>
-{% endblock %}
+{% set breadcrumbs = breadcrumbs([{text: "Get started", href: "/getting-started"}], pageTitle) %}
 
 {% block mainContent %}
   {% if errorMessages.size != 0 %}

--- a/src/views/request.njk
+++ b/src/views/request.njk
@@ -1,19 +1,11 @@
 {% extends "base.njk" %}
-
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-
-{% set pageTitle = "Request to join private beta" %}
 
 {% set showTopNav = false %}
 {% set homePath = "decide" %}
 {% set baseClasses = "govuk-!-padding-top-5" %}
-
-{% block beforeContent %}
-  {{ govukBackLink({
-    text: "Back",
-    href: "/decide/private-beta"
-  }) }}
-{% endblock %}
+{% set pageTitle = "Request to join private beta" %}
+{% set backLink = govukBackLink({text: "Back", href: "/decide/private-beta"}) %}
 
 {% block mainContent %}
   {% if errorMessages.size != 0 %}

--- a/src/views/request.njk
+++ b/src/views/request.njk
@@ -3,7 +3,6 @@
 
 {% set showTopNav = false %}
 {% set homePath = "decide" %}
-{% set baseClasses = "govuk-!-padding-top-5" %}
 {% set pageTitle = "Request to join private beta" %}
 {% set backLink = govukBackLink({text: "Back", href: "/decide/private-beta"}) %}
 

--- a/src/views/roadmap.njk
+++ b/src/views/roadmap.njk
@@ -1,26 +1,9 @@
 {% extends "base-side-nav.njk" %}
+{% from "macros/breadcrumbs.njk" import breadcrumbs %}
 
 {% set pageTitle = "Roadmap" %}
 {% set headerNavigationActiveItem = "features" %}
-
-{% block beforeContent %}
-  <div class="govuk-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#gov-uk-services">GOV.UK services</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="/">GOV.UK Sign In</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="/features">Features</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="#main-content" aria-current="page">Roadmap</a>
-      </li>
-    </ol>
-  </div>
-{% endblock %}
+{% set breadcrumbs = breadcrumbs([{text: "Features", href: "/features"}], pageTitle) %}
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/src/views/support.njk
+++ b/src/views/support.njk
@@ -1,26 +1,12 @@
 {% extends "base.njk" %}
+{% from "macros/breadcrumbs.njk" import breadcrumbs %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% set pageTitle = "Support" %}
 {% set headerNavigationActiveItem = "support" %}
-
-{% block beforeContent %}
-  <div class="govuk-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#gov-uk-services">GOV.UK services</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="/">GOV.UK Sign In</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="#main-content" aria-current="page">Support</a>
-      </li>
-    </ol>
-  </div>
-{% endblock %}
+{% set breadcrumbs = breadcrumbs(currentPageName = pageTitle) %}
 
 {% block mainContent %}
   {% if valueNotSelected %}


### PR DESCRIPTION
**Add a macro to generate breadcrumbs** 

Generate breadcrumbs programmatically by specifying the intermediate crumbs and current page name in the templates.
Use the page title if the current page name is not provided.

Add breadcrumbs placeholder to the `base.njk` template.

---

-  Add placeholder for back link to base.njk
-  Set consistent classes on all views 
   Make the top and bottom spacing consistent on all views and the same as on the self-service pages.