### PR TITLE
DFA-2085: Add macros and layout for forms

### DIFF
--- a/features/register.feature
+++ b/features/register.feature
@@ -49,7 +49,7 @@ Feature: A register form so users can sign up to get access to the GOV.UK Sign I
 
     Given  that the users enter alphanumeric characters into all of the fields in the register form except the mailing-list radio
     When they select the Submit button
-    Then the error message "Select if you’d like to join the mailing list or not" must be displayed for the "mailing-list" field
+    Then the error message "Select if you’d like to join the mailing list or not" must be displayed for the "mailing-list" radios
 
   Scenario: User selects no for the mailing list
 

--- a/features/support.feature
+++ b/features/support.feature
@@ -5,19 +5,19 @@ Feature: A support page which directs users to the correct type of support
 
   Scenario: the user is an end-user
     When the user selects the "I’m a member of the public" radio button
-    And they select the "continue" button
+    And they click the "Continue" button
     Then they should be directed to the following URL: "https://signin.account.gov.uk/contact-us?supportType=PUBLIC"
 
   Scenario: the user is from a new service team
     When the user selects the "I work in a government service team and we want to start using GOV.UK Sign In" radio button
-    And they select the "continue" button
+    And they click the "Continue" button
     Then they should be directed to the following page: "/contact-us-details"
 
   Scenario: the user is from a service team having issues
     When the user selects the "I work in a government service team that is setting up or already using GOV.UK Sign In" radio button
-    And they select the "continue" button
+    And they click the "Continue" button
     Then they should be directed to the following page: "/contact-us"
 
   Scenario: the user doesn't pick an option
-    When they select the "continue" button
+    When they click the "Continue" button
     Then the error message "You must select an option to tell us what you need help with" must be displayed for the "support" radios

--- a/features/support/steps/shared-steps.ts
+++ b/features/support/steps/shared-steps.ts
@@ -23,10 +23,19 @@ When('they click on the {string} button-link', async function (text: string) {
     ]);
 });
 
-When('they select the Submit button', async function () {
+When('they click the {string} button', async function (name: string) {
+    let button = await this.page.$x(`//button[contains(text(), '${name}')]`);
     await Promise.all([
-        this.page.waitForNavigation(),
-        this.page.click('#submit')
+        this.page.waitForNavigation({timeout: 10000}),
+        button[0].click()
+    ]);
+});
+
+When('they select the Submit button', async function () {
+    let button = await this.page.$x(`//button[contains(text(), 'Submit')]`);
+    await Promise.all([
+        this.page.waitForNavigation({timeout: 10000}),
+        button[0].click()
     ]);
 });
 
@@ -49,13 +58,11 @@ Then('their data is saved in the spreadsheet', async function () {
 });
 
 Then('the error message {string} must be displayed for the {string} field', async function (errorMessage, field) {
-    const errorLink = await this.page.$x(`//div[@class="govuk-error-summary"]//a[@href="#${field}"]`);
-    await checkErrorMessageDisplayedAboveElement(this.page, errorLink, errorMessage, field);
+    await checkErrorMessageDisplayedAboveElement(this.page, errorMessage, field);
 });
 
 Then('the error message {string} must be displayed for the {string} radios', async function (errorMessage, field) {
-    const errorLink = await this.page.$x(`//div[@class="govuk-error-summary"]//a[@href="#${field}-error"]`);
-    await checkErrorMessageDisplayedAboveElement(this.page, errorLink, errorMessage, field);
+    await checkErrorMessageDisplayedAboveElement(this.page, errorMessage, field, true);
 });
 
 Then('they should see the text {string}', async function (text) {
@@ -73,15 +80,16 @@ Then('the {string} link will point to the following page: {string}', async funct
     await checkUrl(this.page, link, expectedPage);
 });
 
-async function checkErrorMessageDisplayedAboveElement(page: Page, errorLink: any, errorMessage: string, field: string) {
-    assert.notEqual(errorLink.length, 0, `Expected to find the message ${errorMessage} in the error summary.`);
+async function checkErrorMessageDisplayedAboveElement(page: Page, errorMessage: string, field: string, radios = false) {
+    const errorLink = await page.$x(`//div[@class="govuk-error-summary"]//a[@href="#${field}"]`);
+    assert.notEqual(errorLink.length, 0, `Expected to find the message "${errorMessage}" in the error summary.`);
 
-    const actualMessageInSummary = await page.evaluate((el: { textContent: any; }) => el.textContent, errorLink[0]);
-    assert.equal(actualMessageInSummary, errorMessage, `Expected text of the link to be ${errorMessage}`);
+    const actualMessageInSummary = await page.evaluate((el: {textContent: any}) => el.textContent, errorLink[0]);
+    assert.equal(actualMessageInSummary, errorMessage, `Expected text of the link to be "${errorMessage}"`);
 
-    const messageAboveElement = await page.$x(`//p[@class="govuk-error-message"][@id="${field}-error"]`);
-    assert.notEqual(messageAboveElement.length, 0, `Expected to find the message ${errorMessage} above the ${field} field.`);
+    const messageAboveElement = await page.$x(`//p[@class="govuk-error-message"][@id="${field}${radios ? "-option" : ""}-error"]`);
+    assert.notEqual(messageAboveElement.length, 0, `Expected to find the message "${errorMessage}" above the ${field} field.`);
 
-    const actualMessageAboveSummary = await page.evaluate((el: { textContent: any; }) => el.textContent, messageAboveElement[0]);
-    assert.equal(actualMessageAboveSummary.trim(), `Error: ${errorMessage}`, `Expected the message above the ${field} field to be ${errorMessage}`);
+    const actualMessageAboveSummary = await page.evaluate((el: {textContent: any}) => el.textContent, messageAboveElement[0]);
+    assert.equal(actualMessageAboveSummary.trim(), `Error: ${errorMessage}`, `Expected the message above the ${field} field to be "${errorMessage}"`);
 }

--- a/src/controllers/contact-us.ts
+++ b/src/controllers/contact-us.ts
@@ -1,28 +1,25 @@
-import { Request, Response } from 'express';
+import {Request, Response} from 'express';
 import Validation from "../lib/validation";
 import ZendeskService from "../lib/zendesk/ZendeskService";
 
-let requiredFields = new Map<string, string>();
-requiredFields.set("email", "Enter your government email address");
-requiredFields.set("name", "Enter your name");
-requiredFields.set("role", "Enter your role");
-requiredFields.set("service-name", "Enter the name of your service");
-requiredFields.set("organisation-name", "Enter the name of your organisation");
-requiredFields.set("how-can-we-help", "Tell us how we can help");
+const requiredFields = new Map<string, string>([
+    ["name", "Enter your name"],
+    ["email", "Enter your government email address"],
+    ["role", "Enter your role"],
+    ["organisation-name", "Enter the name of your organisation"],
+    ["service-name", "Enter the name of your service"],
+    ["how-can-we-help", "Tell us how we can help"]
+]);
 
-
-export const showForm = function(req: Request, res: Response) {
-    const errorMessages = new Map();
-    const values = new Map();
-    res.render('contact-us.njk', {errorMessages: errorMessages, values: values});
+export const showForm = function (req: Request, res: Response) {
+    res.render('contact-us.njk');
 }
 
-export const submitForm = async function(req: Request, res: Response) {
-    const values = new Map<string, string>(Object.entries(req.body));
-    values.forEach((value, key) => values.set(key, value.trim()));
+export const submitForm = async function (req: Request, res: Response) {
+    const values = new Map<string, string>();
+    Object.keys(req.body).forEach(key => values.set(key, req.body[key].trim()));
 
     const errorMessages = (req.app.get('validation') as Validation).validate(values, requiredFields);
-
     if (errorMessages.size == 0) {
         const zendesk = new ZendeskService(
             process.env.ZENDESK_USERNAME as string,
@@ -37,23 +34,13 @@ export const submitForm = async function(req: Request, res: Response) {
             res.redirect('contact-us-error')
         }
     } else {
-        res.render('contact-us.njk',
-            {
-                errorMessages: errorMessages,
-                values: values,
-                fieldOrder:
-                    [
-                        "name",
-                        "email",
-                        "role",
-                        "organisation-name",
-                        "service-name",
-                        "how-can-we-help"
-                    ]
-            });
+        res.render('contact-us.njk', {
+            errorMessages: errorMessages,
+            values: values,
+        });
     }
 }
 
-export const confirmation = function(req: Request, res: Response) {
+export const confirmation = function (req: Request, res: Response) {
     res.render('contact-us-confirm.njk');
 }

--- a/src/controllers/decide.ts
+++ b/src/controllers/decide.ts
@@ -4,11 +4,12 @@ import Validation from "../lib/validation";
 import getTimestamp from "../lib/timestamp";
 import uuid from "../lib/uuid";
 
-let requiredFields = new Map<string, string>();
-requiredFields.set("email", "Enter your government email address");
-requiredFields.set("name", "Enter your name");
-requiredFields.set("service-name", "Enter the name of your service");
-requiredFields.set("department-name", "Enter your department");
+let requiredFields = new Map<string, string>([
+    ["name", "Enter your name"],
+    ["email", "Enter your government email address"],
+    ["department-name", "Enter your department"],
+    ["service-name", "Enter the name of your service"]
+]);
 
 export const showRequestForm = function (req: Request, res: Response) {
     const errorMessages = new Map();

--- a/src/controllers/mailing-list.ts
+++ b/src/controllers/mailing-list.ts
@@ -10,12 +10,12 @@ export const mailingList = async function(req: Request, res: Response) {
   const serviceName = req.body.serviceName;
   let errorMessages: Map<String, String> = new Map<String, String>();
 
-  const formValueHolder = {
-    personalName: personalName,
-    organisationName: organisationName,
-    contactEmail: contactEmail,
-    serviceName: serviceName
-  };
+  const values = new Map<string, string>([
+    ["personalName", personalName],
+    ["organisationName", organisationName],
+    ["contactEmail", contactEmail],
+    ["serviceName", serviceName]
+  ]);
 
   const onlyLettersPattern = /^[a-zA-Z\-\s]{1,300}$/;
   const onlyLettersAndNumbersPattern = /^[a-zA-Z\-0-9_\s]{1,300}$/;
@@ -58,7 +58,7 @@ export const mailingList = async function(req: Request, res: Response) {
   }
 
   if(errorMessages.size != 0) {
-    res.render('mailing-list.njk', { errors: errorMessages, values: formValueHolder });
+    res.render('mailing-list.njk', { errorMessages: errorMessages, values: values });
   } else {
 
     let sheet = new SheetsService(process.env.MAILING_LIST_SPREADSHEET_ID as string);

--- a/src/controllers/mailing-list.ts
+++ b/src/controllers/mailing-list.ts
@@ -11,11 +11,11 @@ export const mailingList = async function(req: Request, res: Response) {
   let errorMessages: Map<String, String> = new Map<String, String>();
 
   const formValueHolder = {
-    personalNameHolder: personalName,
-    organisationNameHolder: organisationName,
-    contactEmailHolder: contactEmail,
-    serviceNameHolder: serviceName
-  }
+    personalName: personalName,
+    organisationName: organisationName,
+    contactEmail: contactEmail,
+    serviceName: serviceName
+  };
 
   const onlyLettersPattern = /^[a-zA-Z\-\s]{1,300}$/;
   const onlyLettersAndNumbersPattern = /^[a-zA-Z\-0-9_\s]{1,300}$/;
@@ -42,7 +42,7 @@ export const mailingList = async function(req: Request, res: Response) {
         // @ts-ignore
         return contactEmail.trim().endsWith(suffix) && suffix != "";
       });
-      
+
       if (!isEmailGovUK) {
         errorMessages.set('contactEmail', 'Enter a government email address');
       }

--- a/src/controllers/register.ts
+++ b/src/controllers/register.ts
@@ -4,13 +4,13 @@ import uuid from "../lib/uuid";
 import getTimestamp from "../lib/timestamp";
 import SheetsService from "../lib/sheets/SheetsService";
 
-let requiredFields = new Map<string, string>();
-requiredFields.set("email", "Enter your government email address");
-requiredFields.set("name", "Enter your name");
-requiredFields.set("service-name", "Enter the name of your service");
-requiredFields.set("organisation-name", "Enter your organisation name");
-requiredFields.set("mailing-list", "Select if you’d like to join the mailing list or not");
-
+const requiredFields = new Map<string, string>([
+    ["name", "Enter your name"],
+    ["organisation-name", "Enter your organisation name"],
+    ["email", "Enter your government email address"],
+    ["service-name", "Enter the name of your service"],
+    ["mailing-list", "Select if you’d like to join the mailing list or not"]
+]);
 
 export const get = function(req: Request, res: Response) {
     const errorMessages = new Map();

--- a/src/controllers/support.ts
+++ b/src/controllers/support.ts
@@ -1,22 +1,30 @@
-import { Request, Response } from 'express';
+import {Request, Response} from "express";
+import Validation from "../lib/validation";
 
-export const showForm = function(req: Request, res: Response) {
-    res.render('support.njk');
-}
+const requiredFields = new Map<string, string>([["support", "You must select an option to tell us what you need help with"]]);
 
-export const submitForm = function(req: Request, res: Response) {
-    if (req.body && Object.keys(req.body).length === 0) {
-        res.render('support.njk', {valueNotSelected: true});
-    } else {
-        if (req.body.support === 'gov-service-start-using-sign-in') {
-            res.redirect('/contact-us-details');
-        }
-        if (req.body.support === 'gov-service-uses-sign-in') {
-            res.redirect('/contact-us');
-        }
-        if (req.body.support === 'gov-service-is-public') {
-            res.redirect('https://signin.account.gov.uk/contact-us?supportType=PUBLIC');
-        }
+export const showForm = function (req: Request, res: Response) {
+    res.render("support.njk");
+};
+
+export const submitForm = function (req: Request, res: Response) {
+    const values = new Map<string, string>(Object.entries(req.body));
+    const errorMessages = (req.app.get("validation") as Validation).validate(values, requiredFields);
+
+    if (errorMessages.has("support")) {
+        res.render("support.njk", {errorMessages: errorMessages});
+        return;
     }
-}
 
+    switch (values.get("support")) {
+        case "gov-service-start-using-sign-in":
+            res.redirect("/contact-us-details");
+            return;
+        case "gov-service-uses-sign-in":
+            res.redirect("/contact-us");
+            return;
+        case "gov-service-is-public":
+            res.redirect("https://signin.account.gov.uk/contact-us?supportType=PUBLIC");
+            return;
+    }
+};

--- a/src/lib/validation/validation.ts
+++ b/src/lib/validation/validation.ts
@@ -21,21 +21,30 @@ export default class Validation {
     validate(form: Map<string, string>, requiredFields: Map<string, string>): Map<string, string> {
         const errors = new Map();
 
-        requiredFields.forEach((errorMessage, field) => {
-            if (this.fieldHasNoValue(field, form)) {
-                errors.set(field, errorMessage);
+        Array.from(requiredFields.keys()).forEach(field => {
+            const message = this.getErrorMessage(field, form, requiredFields);
+            if (message) {
+                errors.set(field, message);
             }
-        });
-
-        if (requiredFields.has('email') && !errors.has('email')) {
-            if (this.invalidEmailAddress(form)) {
-                errors.set('email', 'Enter an email address in the correct format, like name@gov.uk');
-            } else if (this.notGovernmentEmail(form)) {
-                errors.set('email', 'Enter a government email address');
-            }
-        }
+        })
 
         return errors;
+    }
+
+    getErrorMessage(field: string, form: Map<string, string>, errorMessages: Map<string, string>): string | undefined {
+        if (this.fieldHasNoValue(field, form)) {
+            return errorMessages.get(field)!;
+        }
+
+        if (field === 'email') {
+            if (this.invalidEmailAddress(form)) {
+                return 'Enter an email address in the correct format, like name@gov.uk';
+            }
+
+            if (this.notGovernmentEmail(form)) {
+                return 'Enter a government email address';
+            }
+        }
     }
 
     fieldHasNoValue(field: string, form: Map<string, string>): boolean {
@@ -62,4 +71,3 @@ export default class Validation {
         return Validation.instance;
     }
 }
-

--- a/src/lib/validation/validation.ts
+++ b/src/lib/validation/validation.ts
@@ -27,7 +27,7 @@ export default class Validation {
             }
         });
 
-        if (!errors.has('email')) {
+        if (requiredFields.has('email') && !errors.has('email')) {
             if (this.invalidEmailAddress(form)) {
                 errors.set('email', 'Enter an email address in the correct format, like name@gov.uk');
             } else if (this.notGovernmentEmail(form)) {

--- a/src/routes/mailing-list.ts
+++ b/src/routes/mailing-list.ts
@@ -1,16 +1,16 @@
-import express from 'express';
-import { mailingList } from "../controllers/mailing-list";
+import express from "express";
+import {mailingList} from "../controllers/mailing-list";
 
 const router = express.Router();
 
-router.get('/mailing-list', (req, res) => {
-  res.render('mailing-list.njk');
+router.get("/mailing-list", (req, res) => {
+    res.render("mailing-list.njk");
 });
 
-router.get('/mailing-list/confirmation', (req, res) => {
-  res.render('mailing-list-confirmation.njk');
+router.get("/mailing-list/confirmation", (req, res) => {
+    res.render("mailing-list-confirmation.njk");
 });
 
-router.post('/mailing-list', mailingList);
+router.post("/mailing-list", mailingList);
 
 export default router;

--- a/src/views/base-form.njk
+++ b/src/views/base-form.njk
@@ -1,0 +1,15 @@
+{% extends "base.njk" %}
+{% import "macros/form.njk" as form with context %}
+{% from "macros/error-summary.njk" import errorSummary %}
+
+{% block mainContent %}
+  {{ errorSummary(errorMessages) }}
+
+  {% block beforeForm %}{% endblock %}
+
+  {% call form.generate(formAction, buttonText, buttonId) %}
+    {% block formInputs %}{% endblock %}
+  {% endcall %}
+
+  {% block afterForm %}{% endblock %}
+{% endblock %}

--- a/src/views/contact-us.njk
+++ b/src/views/contact-us.njk
@@ -1,6 +1,5 @@
 {% extends "base.njk" %}
-{% import "macros/form-inputs.njk" as inputs with context %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
+{% import "macros/form.njk" as form with context %}
 
 {% set pageTitle = "Contact us" %}
 
@@ -35,14 +34,12 @@
     <li>suggest improvements</li>
   </ul>
 
-  <form class="form" method="post" novalidate="novalidate">
-    {{ inputs.textInput("Name", "name") }}
-    {{ inputs.emailInput() }}
-    {{ inputs.textInput("Role", "role") }}
-    {{ inputs.textInput("Organisation", "organisation-name") }}
-    {{ inputs.textInput("Service name", "service-name") }}
-    {{ inputs.textAreaInput("How can we help?", "how-can-we-help") }}
-
-    {{ govukButton({ text: "Submit form", attributes: {id: "submit"} }) }}
-  </form>
+  {% call form.generate(buttonText = "Submit form") %}
+    {{ form.textInput("Name", "name") }}
+    {{ form.emailInput() }}
+    {{ form.textInput("Role", "role") }}
+    {{ form.textInput("Organisation", "organisation-name") }}
+    {{ form.textInput("Service name", "service-name") }}
+    {{ form.textAreaInput("How can we help?", "how-can-we-help") }}
+  {% endcall %}
 {% endblock %}

--- a/src/views/contact-us.njk
+++ b/src/views/contact-us.njk
@@ -1,7 +1,6 @@
 {% extends "base.njk" %}
-{% from "govuk/components/input/macro.njk" import govukInput %}
+{% import "macros/form-inputs.njk" as inputs with context %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 
 {% set pageTitle = "Contact us" %}
 
@@ -37,99 +36,13 @@
   </ul>
 
   <form class="form" method="post" novalidate="novalidate">
-    {{ govukInput({
-      label: {
-        text: "Name"
-      },
-      id: "name",
-      name: "name",
-      spellcheck: false,
-      classes: "govuk-!-width-one-half",
-      value: values.get("name"),
-      errorMessage: {
-        text: errorMessages.get("name")
-      } if errorMessages and errorMessages.has("name")
-    }) }}
+    {{ inputs.textInput("Name", "name") }}
+    {{ inputs.emailInput() }}
+    {{ inputs.textInput("Role", "role") }}
+    {{ inputs.textInput("Organisation", "organisation-name") }}
+    {{ inputs.textInput("Service name", "service-name") }}
+    {{ inputs.textAreaInput("How can we help?", "how-can-we-help") }}
 
-    {{ govukInput({
-      label: {
-        text: "Email address"
-      },
-      hint: {
-        text: "You must enter a government email address"
-      },
-      id: "email",
-      name: "email",
-      type: "email",
-      spellcheck: false,
-      autocomplete: "email",
-      classes: "govuk-!-width-two-thirds",
-      value: values.get("email"),
-      errorMessage: {
-        text: errorMessages.get("email")
-      } if errorMessages and errorMessages.has("email")
-    }) }}
-
-    {{ govukInput({
-      label: {
-        text: "Role"
-      },
-      id: "role",
-      name: "role",
-      spellcheck: false,
-      classes: "govuk-!-width-one-half",
-      value: values.get("role"),
-      errorMessage: {
-        text: errorMessages.get("role")
-      } if errorMessages and errorMessages.has("role")
-    }) }}
-
-    {{ govukInput({
-      label: {
-        text: "Organisation"
-      },
-      id: "organisation-name",
-      name: "organisation-name",
-      spellcheck: false,
-      classes: "govuk-!-width-one-half",
-      value: values.get("organisation-name"),
-      errorMessage: {
-        text: errorMessages.get("organisation-name")
-      } if errorMessages and errorMessages.has("organisation-name")
-    }) }}
-
-    {{ govukInput({
-      label: {
-        text: "Service name"
-      },
-      id: "service-name",
-      name: "service-name",
-      spellcheck: false,
-      classes: "govuk-!-width-one-half",
-      value: values.get("service-name"),
-      errorMessage: {
-        text: errorMessages.get("service-name")
-      } if errorMessages and errorMessages.has("service-name")
-    }) }}
-
-    {{ govukTextarea({
-      label: {
-        text: "How can we help?"
-      },
-      id: "how-can-we-help",
-      name: "how-can-we-help",
-      rows: 5,
-      errorMessage: {
-        text: errorMessages.get("how-can-we-help")
-      } if errorMessages and errorMessages.has("how-can-we-help")
-    }) }}
-
-    {{ govukButton({
-      text: "Submit form",
-      name: "submit",
-      attributes: {
-        id: "submit"
-      }
-    }) }}
+    {{ govukButton({ text: "Submit form", attributes: {id: "submit"} }) }}
   </form>
 {% endblock %}

--- a/src/views/contact-us.njk
+++ b/src/views/contact-us.njk
@@ -1,30 +1,9 @@
-{% extends "base.njk" %}
-{% import "macros/form.njk" as form with context %}
+{% extends "base-form.njk" %}
 
 {% set pageTitle = "Contact us" %}
+{% set buttonText = "Submit form" %}
 
-{% block mainContent %}
-  {% if errorMessages.size != 0 %}
-    <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert"
-         tabindex="-1"
-         data-module="govuk-error-summary">
-      <h2 class="govuk-error-summary__title" id="error-summary-title">
-        There is a problem
-      </h2>
-      <div class="govuk-error-summary__body">
-        <ul class="govuk-list govuk-error-summary__list">
-          {% for field in fieldOrder %}
-            {% if errorMessages.get(field) %}
-              <li>
-                <a href="#{{ field }}">{{ errorMessages.get(field) }}</a>
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
-    </div>
-  {% endif %}
-
+{% block beforeForm %}
   <h1 class="govuk-heading-l govuk-!-margin-bottom-6">Contact us</h1>
 
   <p class="govuk-body">Use this form to:</p>
@@ -33,13 +12,13 @@
     <li>ask questions</li>
     <li>suggest improvements</li>
   </ul>
+{% endblock %}
 
-  {% call form.generate(buttonText = "Submit form") %}
-    {{ form.textInput("Name", "name") }}
-    {{ form.emailInput() }}
-    {{ form.textInput("Role", "role") }}
-    {{ form.textInput("Organisation", "organisation-name") }}
-    {{ form.textInput("Service name", "service-name") }}
-    {{ form.textAreaInput("How can we help?", "how-can-we-help") }}
-  {% endcall %}
+{% block formInputs %}
+  {{ form.textInput("Name", "name") }}
+  {{ form.emailInput() }}
+  {{ form.textInput("Role", "role") }}
+  {{ form.textInput("Organisation", "organisation-name") }}
+  {{ form.textInput("Service name", "service-name") }}
+  {{ form.textAreaInput("How can we help?", "how-can-we-help") }}
 {% endblock %}

--- a/src/views/macros/error-summary.njk
+++ b/src/views/macros/error-summary.njk
@@ -1,11 +1,11 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
-{% macro errorSummary(params) %}
+{% macro errorSummary(errorMessages) %}
   {% set errorList = [] %}
-  {% for key, message in params.errors %}
+  {% for field, message in errorMessages %}
     {% set errorList = (errorList.push({
-      text: message | safe,
-      href: params.hrefs[key]
+      text: message,
+      href: "#" + field
     }), errorList) %}
   {% endfor %}
 

--- a/src/views/macros/form-inputs.njk
+++ b/src/views/macros/form-inputs.njk
@@ -1,0 +1,54 @@
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+
+{% macro textInput(label, id, classes = "govuk-!-width-one-half") %}
+  {{ govukInput({
+    label: {
+      text: label
+    },
+    id: id,
+    name: id,
+    spellcheck: false,
+    classes: classes,
+    value: values.get(id) if values,
+    errorMessage: {
+      text: errorMessages.get(id)
+    } if errorMessages and errorMessages.has(id)
+  }) }}
+{% endmacro %}
+
+{% macro emailInput(label = "Email address", hint = "You must enter a government email address",
+  classes = "govuk-!-width-two-thirds", id = "email") %}
+  {{ govukInput({
+    label: {
+      text: label
+    },
+    hint: {
+      text: hint
+    },
+    id: id,
+    name: id,
+    type: id,
+    spellcheck: false,
+    autocomplete: id,
+    classes: classes,
+    value: values.get(id) if values,
+    errorMessage: {
+      text: errorMessages.get(id)
+    } if errorMessages and errorMessages.has(id)
+  }) }}
+{% endmacro %}
+
+{% macro textAreaInput(label, id, rows = 5) %}
+  {{ govukTextarea({
+    label: {
+      text: label
+    },
+    id: id,
+    name: id,
+    rows: rows,
+    errorMessage: {
+      text: errorMessages.get(id)
+    } if errorMessages and errorMessages.has(id)
+  }) }}
+{% endmacro %}

--- a/src/views/macros/form.njk
+++ b/src/views/macros/form.njk
@@ -3,14 +3,14 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 
-{% macro generate(action, buttonText = "Submit", buttonId = "submit") %}
+{% macro generate(action, buttonText, buttonId) %}
   <form class="form" method="post"{% if action %} action="{{ action }}"{% endif %} novalidate="novalidate">
     {{ caller() }}
 
     {{ govukButton({
-      text: buttonText,
+      text: buttonText | default("Submit"),
       attributes: {
-        id: buttonId | default(buttonText | lower)
+        id: buttonId | default("submit")
       }
     }) }}
   </form>

--- a/src/views/macros/form.njk
+++ b/src/views/macros/form.njk
@@ -1,5 +1,20 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+
+{% macro generate(action, buttonText = "Submit", buttonId = "submit") %}
+  <form class="form" method="post"{% if action %} action="{{ action }}"{% endif %} novalidate="novalidate">
+    {{ caller() }}
+
+    {{ govukButton({
+      text: buttonText,
+      attributes: {
+        id: buttonId | default(buttonText | lower)
+      }
+    }) }}
+  </form>
+{% endmacro %}
 
 {% macro textInput(label, id, classes = "govuk-!-width-one-half") %}
   {{ govukInput({
@@ -47,6 +62,29 @@
     id: id,
     name: id,
     rows: rows,
+    errorMessage: {
+      text: errorMessages.get(id)
+    } if errorMessages and errorMessages.has(id)
+  }) }}
+{% endmacro %}
+
+{% macro radiosInput(label, id, hint, items) %}
+  {{ govukRadios({
+    name: id,
+    idPrefix: id + "-option",
+    attributes: {
+      id: id
+    },
+    fieldset: {
+      legend: {
+        text: label
+      }
+    },
+    hint: {
+      text: hint
+    } if hint,
+    value: values.get(id) if values,
+    items: items,
     errorMessage: {
       text: errorMessages.get(id)
     } if errorMessages and errorMessages.has(id)

--- a/src/views/mailing-list.njk
+++ b/src/views/mailing-list.njk
@@ -1,7 +1,7 @@
 {% extends "base.njk" %}
 {% from "macros/breadcrumbs.njk" import breadcrumbs %}
 {% from "macros/error-summary.njk" import errorSummary %}
-{% from "govuk/components/input/macro.njk" import govukInput %}
+{% import "macros/form-inputs.njk" as inputs with context %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set pageTitle = "Join our mailing list" %}
@@ -9,81 +9,28 @@
 
 {% block mainContent %}
   {{ errorSummary ({
-    errors: errors,
+    errors: errorMessages,
     hrefs: {
-      'personalName': '#personalName',
-      'organisationName': '#organisationName',
-      'contactEmail': '#contactEmail',
-      'serviceName': '#serviceName'
+      personalName: "#personalName",
+      organisationName: "#organisationName",
+      contactEmail: "#contactEmail",
+      serviceName: "#serviceName"
     }
   }) }}
 
   <h1 class="govuk-heading-l">Join our mailing list</h1>
   <p class="govuk-body">Complete this form to stay up to date with our progress on GOV.UK Sign In.</p>
-  <p class="govuk-body">Once you’ve submitted the form, we’ll add you to our mailing list. You’ll get emails with updates about our work. We’ll also invite you to our cross-government show and tells.</p>
+  <p class="govuk-body">
+    Once you’ve submitted the form, we’ll add you to our mailing list. You’ll get emails with updates about our work.
+    We’ll also invite you to our cross-government show and tells.
+  </p>
 
   <form class="form" action="/mailing-list" method="post">
-    {{ govukInput({
-      label: {
-        text: "Name"
-      },
-      name: "personalName",
-      id: "personalName",
-      classes: "govuk-input--width-20",
-      value: values.personalNameHolder,
-      errorMessage: {
-        text: errors.get("personalName")
-      } if errors and errors.has("personalName")
-    }) }}
+    {{ inputs.textInput("Name", "personalName", "govuk-input--width-20") }}
+    {{ inputs.textInput("Organisation name", "organisationName", "govuk-input--width-20") }}
+    {{ inputs.emailInput("Contact email", id = "contactEmail", classes = "govuk-input--width-20") }}
+    {{ inputs.textInput("Service name", "serviceName", "govuk-input--width-30") }}
 
-    {{ govukInput({
-      label: {
-        text: "Organisation name"
-      },
-      name: "organisationName",
-      id: "organisationName",
-      classes: "govuk-input--width-20",
-      value: values.organisationNameHolder,
-      errorMessage: {
-        text: errors.get("organisationName")
-      } if errors and errors.has("organisationName")
-    }) }}
-
-    {{ govukInput({
-      label: {
-        text: "Contact email"
-      },
-      name: "contactEmail",
-      id: "contactEmail",
-      classes: "govuk-input--width-20",
-      value: values.contactEmailHolder,
-      hint: {
-        text: "You must enter a government email address"
-      },
-      errorMessage: {
-        text: errors.get("contactEmail")
-      } if errors and errors.has("contactEmail")
-    }) }}
-
-    {{ govukInput({
-      label: {
-        text: "Service name"
-      },
-      name: "serviceName",
-      id: "serviceName",
-      classes: "govuk-input--width-30",
-      value: values.serviceNameHolder,
-      errorMessage: {
-        text: errors.get("serviceName")
-      } if errors and errors.has("serviceName")
-    }) }}
-
-    {{ govukButton({
-      text: "Submit",
-      name: "submit",
-      attributes: {
-        id: "submit"
-      }
-    }) }}
+    {{ govukButton({ text: "Submit", attributes: {id: "submit"} }) }}
   </form>
 {% endblock %}

--- a/src/views/mailing-list.njk
+++ b/src/views/mailing-list.njk
@@ -1,33 +1,23 @@
-{% extends "base.njk" %}
-{% from "macros/breadcrumbs.njk" import breadcrumbs %}
-{% from "macros/error-summary.njk" import errorSummary %}
+{% extends "base-form.njk" %}
 {% import "macros/form.njk" as form with context %}
+{% from "macros/breadcrumbs.njk" import breadcrumbs %}
 
+{% set formAction = "/mailing-list" %}
 {% set pageTitle = "Join our mailing list" %}
 {% set breadcrumbs = breadcrumbs(currentPageName = pageTitle) %}
 
-{% block mainContent %}
-  {{ errorSummary ({
-    errors: errorMessages,
-    hrefs: {
-      personalName: "#personalName",
-      organisationName: "#organisationName",
-      contactEmail: "#contactEmail",
-      serviceName: "#serviceName"
-    }
-  }) }}
-
+{% block beforeForm %}
   <h1 class="govuk-heading-l">Join our mailing list</h1>
   <p class="govuk-body">Complete this form to stay up to date with our progress on GOV.UK Sign In.</p>
   <p class="govuk-body">
     Once you’ve submitted the form, we’ll add you to our mailing list. You’ll get emails with updates about our work.
     We’ll also invite you to our cross-government show and tells.
   </p>
+{% endblock %}
 
-  {% call form.generate("/mailing-list") %}
-    {{ form.textInput("Name", "personalName", "govuk-input--width-20") }}
-    {{ form.textInput("Organisation name", "organisationName", "govuk-input--width-20") }}
-    {{ form.emailInput("Contact email", id = "contactEmail", classes = "govuk-input--width-20") }}
-    {{ form.textInput("Service name", "serviceName", "govuk-input--width-30") }}
-  {% endcall %}
+{% block formInputs %}
+  {{ form.textInput("Name", "personalName", "govuk-input--width-20") }}
+  {{ form.textInput("Organisation name", "organisationName", "govuk-input--width-20") }}
+  {{ form.emailInput("Contact email", id = "contactEmail", classes = "govuk-input--width-20") }}
+  {{ form.textInput("Service name", "serviceName", "govuk-input--width-30") }}
 {% endblock %}

--- a/src/views/mailing-list.njk
+++ b/src/views/mailing-list.njk
@@ -1,8 +1,7 @@
 {% extends "base.njk" %}
 {% from "macros/breadcrumbs.njk" import breadcrumbs %}
 {% from "macros/error-summary.njk" import errorSummary %}
-{% import "macros/form-inputs.njk" as inputs with context %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
+{% import "macros/form.njk" as form with context %}
 
 {% set pageTitle = "Join our mailing list" %}
 {% set breadcrumbs = breadcrumbs(currentPageName = pageTitle) %}
@@ -25,12 +24,10 @@
     We’ll also invite you to our cross-government show and tells.
   </p>
 
-  <form class="form" action="/mailing-list" method="post">
-    {{ inputs.textInput("Name", "personalName", "govuk-input--width-20") }}
-    {{ inputs.textInput("Organisation name", "organisationName", "govuk-input--width-20") }}
-    {{ inputs.emailInput("Contact email", id = "contactEmail", classes = "govuk-input--width-20") }}
-    {{ inputs.textInput("Service name", "serviceName", "govuk-input--width-30") }}
-
-    {{ govukButton({ text: "Submit", attributes: {id: "submit"} }) }}
-  </form>
+  {% call form.generate("/mailing-list") %}
+    {{ form.textInput("Name", "personalName", "govuk-input--width-20") }}
+    {{ form.textInput("Organisation name", "organisationName", "govuk-input--width-20") }}
+    {{ form.emailInput("Contact email", id = "contactEmail", classes = "govuk-input--width-20") }}
+    {{ form.textInput("Service name", "serviceName", "govuk-input--width-30") }}
+  {% endcall %}
 {% endblock %}

--- a/src/views/register.njk
+++ b/src/views/register.njk
@@ -1,53 +1,32 @@
-{% extends "base.njk" %}
+{% extends "base-form.njk" %}
 {% from "macros/breadcrumbs.njk" import breadcrumbs %}
-{% import "macros/form.njk" as form with context %}
 
 {% set pageTitle = "Sign up to get access" %}
 {% set breadcrumbs = breadcrumbs([{text: "Get started", href: "/getting-started"}], pageTitle) %}
 
-{% block mainContent %}
-  {% if errorMessages.size != 0 %}
-    <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1"
-         data-module="govuk-error-summary">
-      <h2 class="govuk-error-summary__title" id="error-summary-title">
-        There is a problem
-      </h2>
-      <div class="govuk-error-summary__body">
-        <ul class="govuk-list govuk-error-summary__list">
-          {% for field in fieldOrder %}
-            {% if errorMessages.get(field) %}
-              <li>
-                <a href="#{{ field }}">{{ errorMessages.get(field) }}</a>
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
-    </div>
-  {% endif %}
-
+{% block beforeForm %}
   <h1 class="govuk-heading-l">Sign up to get access</h1>
   <p class="govuk-body">Complete this form if you’re from a central government service team and want to try out GOV.UK Sign In.</p>
   <p class="govuk-body">Once you’ve submitted it, we’ll get in touch to learn more about your service and give you access to our test environment (or ‘sandbox’).</p>
+{% endblock %}
 
-  {% call form.generate() %}
-    {{ form.textInput("Name", "name", "govuk-!-width-two-thirds") }}
-    {{ form.textInput("Organisation name", "organisation-name", "govuk-!-width-two-thirds") }}
-    {{ form.emailInput("Contact email") }}
-    {{ form.textInput("Service name", "service-name", "govuk-!-width-full") }}
-    {{ form.radiosInput("Would you like to join our mailing list?", id = "mailing-list",
-      hint = "You’ll get occasional email updates about our work and invitations to our cross-government show and tells.",
-      items = [
-        {
-          text: "Yes",
-          value: "yes",
-          id: "mailing-list-yes"
-        },
-        {
-          text: "No",
-          value: "no",
-          id: "mailing-list-no"
-        }
-      ]) }}
-  {% endcall %}
+{% block formInputs %}
+  {{ form.textInput("Name", "name", "govuk-!-width-two-thirds") }}
+  {{ form.textInput("Organisation name", "organisation-name", "govuk-!-width-two-thirds") }}
+  {{ form.emailInput("Contact email") }}
+  {{ form.textInput("Service name", "service-name", "govuk-!-width-full") }}
+  {{ form.radiosInput("Would you like to join our mailing list?", id = "mailing-list",
+    hint = "You’ll get occasional email updates about our work and invitations to our cross-government show and tells.",
+    items = [
+      {
+        text: "Yes",
+        value: "yes",
+        id: "mailing-list-yes"
+      },
+      {
+        text: "No",
+        value: "no",
+        id: "mailing-list-no"
+      }
+    ]) }}
 {% endblock %}

--- a/src/views/register.njk
+++ b/src/views/register.njk
@@ -1,6 +1,6 @@
 {% extends "base.njk" %}
 {% from "macros/breadcrumbs.njk" import breadcrumbs %}
-{% from "govuk/components/input/macro.njk" import govukInput %}
+{% import "macros/form-inputs.njk" as inputs with context %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
@@ -33,65 +33,10 @@
   <p class="govuk-body">Once you’ve submitted it, we’ll get in touch to learn more about your service and give you access to our test environment (or ‘sandbox’).</p>
 
   <form class="form" method="post" novalidate="novalidate">
-    {{ govukInput({
-      label: {
-        text: "Name"
-      },
-      id: "name",
-      name: "name",
-      spellcheck: false,
-      classes: "govuk-!-width-two-thirds",
-      value: values.get('name'),
-      errorMessage: {
-        text: errorMessages.get('name')
-      } if errorMessages and errorMessages.has('name')
-    }) }}
-
-    {{ govukInput({
-      label: {
-        text: "Organisation name"
-      },
-      id: "organisation-name",
-      name: "organisation-name",
-      spellcheck: false,
-      classes: "govuk-!-width-two-thirds",
-      value: values.get('organisation-name'),
-      errorMessage: {
-        text: errorMessages.get('organisation-name')
-      } if errorMessages and errorMessages.has('organisation-name')
-    }) }}
-
-    {{ govukInput({
-      label: {
-        text: "Contact email"
-      },
-      hint: {
-        text: "You must enter a government email address"
-      },
-      id: "email",
-      name: "email",
-      type: "email",
-      spellcheck: false,
-      autocomplete: "email",
-      classes: "govuk-!-width-two-thirds",
-      value: values.get("email"),
-      errorMessage: {
-        text: errorMessages.get("email")
-      } if errorMessages and errorMessages.has("email")
-    }) }}
-
-    {{ govukInput({
-      label: {
-        text: "Service name"
-      },
-      id: "service-name",
-      name: "service-name",
-      spellcheck: false,
-      value: values.get("service-name"),
-      errorMessage: {
-        text: errorMessages.get("service-name")
-      } if errorMessages and errorMessages.has("service-name")
-    }) }}
+    {{ inputs.textInput("Name", "name", "govuk-!-width-two-thirds") }}
+    {{ inputs.textInput("Organisation name", "organisation-name", "govuk-!-width-two-thirds") }}
+    {{ inputs.emailInput("Contact email") }}
+    {{ inputs.textInput("Service name", "service-name", "govuk-!-width-full") }}
 
     {{ govukRadios({
       name: "mailing-list",
@@ -123,12 +68,6 @@
       } if errorMessages and errorMessages.has("mailing-list")
     }) }}
 
-    {{ govukButton({
-      text: "Submit",
-      name: "submit",
-      attributes: {
-        id: "submit"
-      }
-    }) }}
+    {{ govukButton({ text: "Submit", attributes: {id: "submit"} }) }}
   </form>
 {% endblock %}

--- a/src/views/register.njk
+++ b/src/views/register.njk
@@ -1,8 +1,6 @@
 {% extends "base.njk" %}
 {% from "macros/breadcrumbs.njk" import breadcrumbs %}
-{% import "macros/form-inputs.njk" as inputs with context %}
-{% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
+{% import "macros/form.njk" as form with context %}
 
 {% set pageTitle = "Sign up to get access" %}
 {% set breadcrumbs = breadcrumbs([{text: "Get started", href: "/getting-started"}], pageTitle) %}
@@ -32,26 +30,14 @@
   <p class="govuk-body">Complete this form if you’re from a central government service team and want to try out GOV.UK Sign In.</p>
   <p class="govuk-body">Once you’ve submitted it, we’ll get in touch to learn more about your service and give you access to our test environment (or ‘sandbox’).</p>
 
-  <form class="form" method="post" novalidate="novalidate">
-    {{ inputs.textInput("Name", "name", "govuk-!-width-two-thirds") }}
-    {{ inputs.textInput("Organisation name", "organisation-name", "govuk-!-width-two-thirds") }}
-    {{ inputs.emailInput("Contact email") }}
-    {{ inputs.textInput("Service name", "service-name", "govuk-!-width-full") }}
-
-    {{ govukRadios({
-      name: "mailing-list",
-      attributes: {
-        id: "mailing-list"
-      },
-      fieldset: {
-        legend: {
-          text: "Would you like to join our mailing list?"
-        }
-      },
-      hint: {
-        text: "You’ll get occasional email updates about our work and invitations to our cross-government show and tells."
-      },
-      items: [
+  {% call form.generate() %}
+    {{ form.textInput("Name", "name", "govuk-!-width-two-thirds") }}
+    {{ form.textInput("Organisation name", "organisation-name", "govuk-!-width-two-thirds") }}
+    {{ form.emailInput("Contact email") }}
+    {{ form.textInput("Service name", "service-name", "govuk-!-width-full") }}
+    {{ form.radiosInput("Would you like to join our mailing list?", id = "mailing-list",
+      hint = "You’ll get occasional email updates about our work and invitations to our cross-government show and tells.",
+      items = [
         {
           text: "Yes",
           value: "yes",
@@ -62,12 +48,6 @@
           value: "no",
           id: "mailing-list-no"
         }
-      ],
-      errorMessage: {
-        text: errorMessages.get("mailing-list")
-      } if errorMessages and errorMessages.has("mailing-list")
-    }) }}
-
-    {{ govukButton({ text: "Submit", attributes: {id: "submit"} }) }}
-  </form>
+      ]) }}
+  {% endcall %}
 {% endblock %}

--- a/src/views/request.njk
+++ b/src/views/request.njk
@@ -1,39 +1,18 @@
-{% extends "base.njk" %}
+{% extends "base-form.njk" %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-{% import "macros/form.njk" as form with context %}
 
 {% set showTopNav = false %}
 {% set homePath = "decide" %}
 {% set pageTitle = "Request to join private beta" %}
 {% set backLink = govukBackLink({text: "Back", href: "/decide/private-beta"}) %}
 
-{% block mainContent %}
-  {% if errorMessages.size != 0 %}
-    <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1"
-         data-module="govuk-error-summary">
-      <h2 class="govuk-error-summary__title" id="error-summary-title">
-        There is a problem
-      </h2>
-      <div class="govuk-error-summary__body">
-        <ul class="govuk-list govuk-error-summary__list">
-          {% for field in fieldOrder %}
-            {% if errorMessages.get(field) %}
-              <li>
-                <a href="#{{ field }}">{{ errorMessages.get(field) }}</a>
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
-    </div>
-  {% endif %}
-
+{% block beforeForm %}
   <h1 class="govuk-heading-l govuk-!-margin-bottom-7">Request to join private beta</h1>
+{% endblock %}
 
-  {% call form.generate() %}
-    {{ form.textInput("Name", "name") }}
-    {{ form.emailInput(hint = "Must be a government email address") }}
-    {{ form.textInput("Department", "department-name") }}
-    {{ form.textInput("Service name", "service-name") }}
-  {% endcall %}
+{% block formInputs %}
+  {{ form.textInput("Name", "name") }}
+  {{ form.emailInput(hint = "Must be a government email address") }}
+  {{ form.textInput("Department", "department-name") }}
+  {{ form.textInput("Service name", "service-name") }}
 {% endblock %}

--- a/src/views/request.njk
+++ b/src/views/request.njk
@@ -1,7 +1,6 @@
 {% extends "base.njk" %}
-{% import "macros/form-inputs.njk" as inputs with context %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% import "macros/form.njk" as form with context %}
 
 {% set showTopNav = false %}
 {% set homePath = "decide" %}
@@ -31,12 +30,10 @@
 
   <h1 class="govuk-heading-l govuk-!-margin-bottom-7">Request to join private beta</h1>
 
-  <form class="form" method="post" novalidate="novalidate">
-    {{ inputs.textInput("Name", "name") }}
-    {{ inputs.emailInput(hint = "Must be a government email address") }}
-    {{ inputs.textInput("Department", "department-name") }}
-    {{ inputs.textInput("Service name", "service-name") }}
-
-    {{ govukButton({ text: "Submit", attributes: {id: "submit"} }) }}
-  </form>
+  {% call form.generate() %}
+    {{ form.textInput("Name", "name") }}
+    {{ form.emailInput(hint = "Must be a government email address") }}
+    {{ form.textInput("Department", "department-name") }}
+    {{ form.textInput("Service name", "service-name") }}
+  {% endcall %}
 {% endblock %}

--- a/src/views/request.njk
+++ b/src/views/request.njk
@@ -1,5 +1,5 @@
 {% extends "base.njk" %}
-{% from "govuk/components/input/macro.njk" import govukInput %}
+{% import "macros/form-inputs.njk" as inputs with context %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
@@ -32,72 +32,11 @@
   <h1 class="govuk-heading-l govuk-!-margin-bottom-7">Request to join private beta</h1>
 
   <form class="form" method="post" novalidate="novalidate">
-    {{ govukInput({
-      label: {
-        text: "Name"
-      },
-      id: "name",
-      name: "name",
-      spellcheck: false,
-      classes: "govuk-!-width-one-half",
-      value: values.get("name"),
-      errorMessage: {
-        text: errorMessages.get("name")
-      } if errorMessages and errorMessages.has("name")
-    }) }}
+    {{ inputs.textInput("Name", "name") }}
+    {{ inputs.emailInput(hint = "Must be a government email address") }}
+    {{ inputs.textInput("Department", "department-name") }}
+    {{ inputs.textInput("Service name", "service-name") }}
 
-    {{ govukInput({
-      label: {
-        text: "Email address"
-      },
-      hint: {
-        text: "Must be a government email address"
-      },
-      id: "email",
-      name: "email",
-      type: "email",
-      spellcheck: false,
-      autocomplete: "email",
-      classes: "govuk-!-width-two-thirds",
-      value: values.get("email"),
-      errorMessage: {
-        text: errorMessages.get("email")
-      } if errorMessages and errorMessages.has("email")
-    }) }}
-
-    {{ govukInput({
-      label: {
-        text: "Department"
-      },
-      id: "department-name",
-      name: "department-name",
-      spellcheck: false,
-      classes: "govuk-!-width-one-half",
-      value: values.get("department-name"),
-      errorMessage: {
-        text: errorMessages.get("department-name")
-      } if errorMessages and errorMessages.has("department-name")
-    }) }}
-
-    {{ govukInput({
-      label: {
-        text: "Service name"
-      },
-      id: "service-name",
-      name: "service-name",
-      spellcheck: false,
-      classes: "govuk-input govuk-!-width-one-half",
-      value: values.get("service-name"),
-      errorMessage: {
-        text: errorMessages.get("service-name")
-      } if errorMessages and errorMessages.has("service-name")
-    }) }}
-
-    {{ govukButton({
-      text: "Submit",
-      attributes: {
-        id: "submit"
-      }
-    }) }}
+    {{ govukButton({ text: "Submit", attributes: {id: "submit"} }) }}
   </form>
 {% endblock %}

--- a/src/views/support.njk
+++ b/src/views/support.njk
@@ -1,97 +1,41 @@
 {% extends "base.njk" %}
+{% import "macros/form.njk" as form with context %}
 {% from "macros/breadcrumbs.njk" import breadcrumbs %}
-{% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "macros/error-summary.njk" import errorSummary %}
 
 {% set pageTitle = "Support" %}
 {% set headerNavigationActiveItem = "support" %}
 {% set breadcrumbs = breadcrumbs(currentPageName = pageTitle) %}
 
 {% block mainContent %}
-  {% if valueNotSelected %}
-    {{ govukErrorSummary({
-      titleText: "There is a problem",
-      errorList: [
-        {
-          text: "You must select an option to tell us what you need help with",
-          href: "#support-error"
-        }
-      ]
-    }) }}
-  {% endif %}
+  {{ errorSummary ({
+    errors: errorMessages,
+    hrefs: {
+      support: "#support"
+    }
+  }) }}
 
   <h1 class="govuk-heading-l">Support</h1>
 
-  <form action="/support" method="post" novalidate>
-
-    {% if valueNotSelected %}
-
-      {{ govukRadios({
-        idPrefix: "support",
-        name: "support",
-        fieldset: {
-          legend: {
-            text: "What do you need help with?"
-          }
+  {% call form.generate(action = "/support", buttonText = "Continue") %}
+    {{ form.radiosInput("What do you need help with?", id = "support",
+      items = [
+        {
+          text: "I work in a government service team and we want to start using GOV.UK Sign In",
+          value: "gov-service-start-using-sign-in"
         },
-        errorMessage: {
-          text: "You must select an option to tell us what you need help with"
+        {
+          text: "I work in a government service team that is setting up or already using GOV.UK Sign In",
+          value: "gov-service-uses-sign-in"
         },
-        items: [
-          {
-            value: "gov-service-start-using-sign-in",
-            text: "I work in a government service team and we want to start using GOV.UK Sign In"
-          },
-          {
-            value: "gov-service-uses-sign-in",
-            text: "I work in a government service team that is setting up or already using GOV.UK Sign In"
-          },
-          {
-            value: "gov-service-is-public",
-            text: "I’m a member of the public"
-          }
-        ]
-      }) }}
-
-    {% else %}
-
-      {{ govukRadios({
-        idPrefix: "support",
-        name: "support",
-        fieldset: {
-          legend: {
-            text: "What do you need help with?"
-          }
-        },
-        items: [
-          {
-            value: "gov-service-start-using-sign-in",
-            text: "I work in a government service team and we want to start using GOV.UK Sign In"
-          },
-          {
-            value: "gov-service-uses-sign-in",
-            text: "I work in a government service team that is setting up or already using GOV.UK Sign In"
-          },
-          {
-            value: "gov-service-is-public",
-            text: "I’m a member of the public"
-          }
-        ]
-      }) }}
-
-    {% endif %}
-
-    {{ govukButton({
-      text: "Continue",
-      attributes: {"id": "continue"}
-    }) }}
-
-  </form>
+        {
+          text: "I’m a member of the public",
+          value: "gov-service-is-public"
+        }
+      ]) }}
+  {% endcall %}
 
   <h2 class="govuk-heading-m">Office hours</h2>
-
   <p class="govuk-body">We can only respond to your support queries during office hours. Our office hours are 9:30am to 5:30pm, Monday to Friday.</p>
-
   <p class="govuk-body">When you get in touch during office hours, we’ll try to reply within 2 working days.</p>
 {% endblock %}

--- a/src/views/support.njk
+++ b/src/views/support.njk
@@ -1,40 +1,35 @@
-{% extends "base.njk" %}
-{% import "macros/form.njk" as form with context %}
+{% extends "base-form.njk" %}
 {% from "macros/breadcrumbs.njk" import breadcrumbs %}
-{% from "macros/error-summary.njk" import errorSummary %}
 
 {% set pageTitle = "Support" %}
 {% set headerNavigationActiveItem = "support" %}
 {% set breadcrumbs = breadcrumbs(currentPageName = pageTitle) %}
+{% set formAction = "/support" %}
+{% set buttonText = "Continue" %}
 
-{% block mainContent %}
-  {{ errorSummary ({
-    errors: errorMessages,
-    hrefs: {
-      support: "#support"
-    }
-  }) }}
-
+{% block beforeForm %}
   <h1 class="govuk-heading-l">Support</h1>
+{% endblock %}
 
-  {% call form.generate(action = "/support", buttonText = "Continue") %}
-    {{ form.radiosInput("What do you need help with?", id = "support",
-      items = [
-        {
-          text: "I work in a government service team and we want to start using GOV.UK Sign In",
-          value: "gov-service-start-using-sign-in"
-        },
-        {
-          text: "I work in a government service team that is setting up or already using GOV.UK Sign In",
-          value: "gov-service-uses-sign-in"
-        },
-        {
-          text: "I’m a member of the public",
-          value: "gov-service-is-public"
-        }
-      ]) }}
-  {% endcall %}
+{% block formInputs %}
+  {{ form.radiosInput("What do you need help with?", id = "support",
+    items = [
+      {
+        text: "I work in a government service team and we want to start using GOV.UK Sign In",
+        value: "gov-service-start-using-sign-in"
+      },
+      {
+        text: "I work in a government service team that is setting up or already using GOV.UK Sign In",
+        value: "gov-service-uses-sign-in"
+      },
+      {
+        text: "I’m a member of the public",
+        value: "gov-service-is-public"
+      }
+    ]) }}
+{% endblock %}
 
+{% block afterForm %}
   <h2 class="govuk-heading-m">Office hours</h2>
   <p class="govuk-body">We can only respond to your support queries during office hours. Our office hours are 9:30am to 5:30pm, Monday to Friday.</p>
   <p class="govuk-body">When you get in touch during office hours, we’ll try to reply within 2 working days.</p>


### PR DESCRIPTION
- Add a base template for views that need to display forms 
The template automatically generates the form and error summary if errors are present.
This fixes the "Incorrectly Labelled Form Fields" issue as incorrect labels were assigned due to bad a copy/paste process.
The forms now automatically generate correct hrefs for fields with errors.

- Make macros for reusable form inputs 
  Generate form inputs using the macros

- Add a macro to generate a form 