### PR TITLE
DFA-2085: Point to the first radio button on error

### DIFF
--- a/features/support/steps/base-template-steps.ts
+++ b/features/support/steps/base-template-steps.ts
@@ -1,19 +1,18 @@
-import { Given, Then, When } from '@cucumber/cucumber';
-import { assert } from 'chai';
+import {Given, Then, When} from "@cucumber/cucumber";
+import {assert} from "chai";
 
-
-Given('the user is browsing with a viewport {int} pixels wide', async function (width: number) {
-    await this.page.setViewport({ height: 400, width: width })
+Given("the user is browsing with a viewport {int} pixels wide", async function (width: number) {
+    await this.page.setViewport({height: 400, width: width});
 });
 
-When('the user clicks the button with the text {string}', async function (text: string) {
-    let button = await this.page.$x(`//button[contains(text(), '${text}')]`);
-    await button[0].click()
+When("the user clicks the button with the text {string}", async function (text: string) {
+    const button = await this.page.$x(`//button[contains(text(), '${text}')]`);
+    await button[0].click();
 });
 
-Then('they should see a menu item {string} that points to the page {string}', async function (text: string, page: string) {
-    let items = await this.page.$x(`//li[@class="govuk-header__navigation-item"]/a[text()="${text}"]`);
-    assert.equal(items.length, 1, `Could not find ${text} in menu`)
-    const href = await this.page.evaluate((anchor: any) => anchor.getAttribute('href'), items[0]);
-    assert.equal(href, page, `Link does not point to ${page} but points to ${href} instead`)
+Then("they should see a menu item {string} that points to the page {string}", async function (text: string, page: string) {
+    const items = await this.page.$x(`//li[@class="govuk-header__navigation-item"]/a[text()="${text}"]`);
+    assert.equal(items.length, 1, `Could not find ${text} in menu`);
+    const href = await this.page.evaluate((anchor: any) => anchor.getAttribute("href"), items[0]);
+    assert.equal(href, page, `Link does not point to ${page} but points to ${href} instead`);
 });

--- a/features/support/steps/contact-us-steps.ts
+++ b/features/support/steps/contact-us-steps.ts
@@ -1,80 +1,98 @@
-import { Given, Then } from '@cucumber/cucumber';
-import { Page } from 'puppeteer';
+import {Given, Then} from "@cucumber/cucumber";
+import {Page} from "puppeteer";
 
-Given('that the users enter alphanumeric characters into all of the fields in the contact us form', async function () {
-    await this.goToPath('/contact-us');
+Given("that the users enter alphanumeric characters into all of the fields in the contact us form", async function () {
+    await this.goToPath("/contact-us");
     await fillInUserInfoFields(this.page);
-    await this.page.type('#how-can-we-help', "We'd like fairies to be able to sign up to get their unicorns tested.");
+    await this.page.type("#how-can-we-help", "We'd like fairies to be able to sign up to get their unicorns tested.");
 });
 
-Given('that the users enter alphanumeric characters into all of the fields in the contact us form except the name field', async function () {
-    await this.goToPath('/contact-us');
-    await this.page.type('#role', 'Chief Unicorn Tester');
-    await this.page.type('#email', 'tessa.ting@gov.uk');
-    await this.page.type('#service-name', 'Unicorn Testing');
-    await this.page.type('#organisation-name', 'Department of Sorcery');
-    await this.page.type('#how-can-we-help', "We'd like fairies to be able to sign up to get their unicorns tested.");
+Given(
+    "that the users enter alphanumeric characters into all of the fields in the contact us form except the name field",
+    async function () {
+        await this.goToPath("/contact-us");
+        await this.page.type("#role", "Chief Unicorn Tester");
+        await this.page.type("#email", "tessa.ting@gov.uk");
+        await this.page.type("#service-name", "Unicorn Testing");
+        await this.page.type("#organisation-name", "Department of Sorcery");
+        await this.page.type("#how-can-we-help", "We'd like fairies to be able to sign up to get their unicorns tested.");
+    }
+);
+
+Given(
+    "that the users enter alphanumeric characters into all of the fields in the contact us form except the email field",
+    async function () {
+        await this.goToPath("/contact-us");
+        await this.page.type("#name", "Tessa Ting");
+        await this.page.type("#role", "Chief Unicorn Tester");
+        await this.page.type("#service-name", "Unicorn Testing");
+        await this.page.type("#organisation-name", "Department of Sorcery");
+        await this.page.type("#how-can-we-help", "We'd like fairies to be able to sign up to get their unicorns tested.");
+    }
+);
+
+Given(
+    "that the users enter alphanumeric characters into all of the fields in the contact us form except the role field",
+    async function () {
+        await this.goToPath("/contact-us");
+        await this.page.type("#name", "Tessa Ting");
+        await this.page.type("#service-name", "Unicorn Testing");
+        await this.page.type("#organisation-name", "Department of Sorcery");
+        await this.page.type("#how-can-we-help", "We'd like fairies to be able to sign up to get their unicorns tested.");
+    }
+);
+
+Given(
+    "that the users enter alphanumeric characters into all of the fields in the contact us form except the organisation-name field",
+    async function () {
+        await this.goToPath("/contact-us");
+        await this.page.type("#email", "tessa.ting@gov.uk");
+        await this.page.type("#name", "Tessa Ting");
+        await this.page.type("#role", "Chief Unicorn Tester");
+        await this.page.type("#service-name", "Unicorn Testing");
+        await this.page.type("#how-can-we-help", "We'd like fairies to be able to sign up to get their unicorns tested.");
+    }
+);
+
+Given(
+    "that the users enter alphanumeric characters into all of the fields in the contact us form except the service-name field",
+    async function () {
+        await this.goToPath("/contact-us");
+        await this.page.type("#email", "tessa.ting@gov.uk");
+        await this.page.type("#name", "Tessa Ting");
+        await this.page.type("#role", "Chief Unicorn Tester");
+        await this.page.type("#organisation-name", "Department of Sorcery");
+        await this.page.type("#how-can-we-help", "We'd like fairies to be able to sign up to get their unicorns tested.");
+    }
+);
+
+Given(
+    "that the users enter alphanumeric characters into all of the fields in the contact us form except the how-can-we-help field",
+    async function () {
+        await this.goToPath("/contact-us");
+        await fillInUserInfoFields(this.page);
+    }
+);
+
+Given("that the user enters an invalid email address into the email field of the contact us form", async function () {
+    await this.goToPath("/contact-us");
+    await this.page.type("#email", "1 Station Road, Newtown, Countyshire AB1 2CD");
 });
 
-Given('that the users enter alphanumeric characters into all of the fields in the contact us form except the email field', async function () {
-    await this.goToPath('/contact-us');
-    await this.page.type('#name', 'Tessa Ting');
-    await this.page.type('#role', 'Chief Unicorn Tester');
-    await this.page.type('#service-name', 'Unicorn Testing');
-    await this.page.type('#organisation-name', 'Department of Sorcery');
-    await this.page.type('#how-can-we-help', "We'd like fairies to be able to sign up to get their unicorns tested.");
+Given("that the user enters a non-government email address into the email field of the contact us form", async function () {
+    await this.goToPath("/contact-us");
+    await this.page.type("#email", "bill@microsoft.com");
 });
 
-Given('that the users enter alphanumeric characters into all of the fields in the contact us form except the role field', async function () {
-    await this.goToPath('/contact-us');
-    await this.page.type('#name', 'Tessa Ting');
-    await this.page.type('#service-name', 'Unicorn Testing');
-    await this.page.type('#organisation-name', 'Department of Sorcery');
-    await this.page.type('#how-can-we-help', "We'd like fairies to be able to sign up to get their unicorns tested.");
-});
-
-Given('that the users enter alphanumeric characters into all of the fields in the contact us form except the organisation-name field', async function () {
-    await this.goToPath('/contact-us');
-    await this.page.type('#email', 'tessa.ting@gov.uk');
-    await this.page.type('#name', 'Tessa Ting');
-    await this.page.type('#role', 'Chief Unicorn Tester');
-    await this.page.type('#service-name', 'Unicorn Testing');
-    await this.page.type('#how-can-we-help', "We'd like fairies to be able to sign up to get their unicorns tested.");
-});
-
-Given('that the users enter alphanumeric characters into all of the fields in the contact us form except the service-name field', async function () {
-    await this.goToPath('/contact-us');
-    await this.page.type('#email', 'tessa.ting@gov.uk');
-    await this.page.type('#name', 'Tessa Ting');
-    await this.page.type('#role', 'Chief Unicorn Tester');
-    await this.page.type('#organisation-name', 'Department of Sorcery');
-    await this.page.type('#how-can-we-help', "We'd like fairies to be able to sign up to get their unicorns tested.");
-});
-
-Given('that the users enter alphanumeric characters into all of the fields in the contact us form except the how-can-we-help field', async function () {
-    await this.goToPath('/contact-us');
-    await fillInUserInfoFields(this.page);
-});
-
-Given('that the user enters an invalid email address into the email field of the contact us form', async function () {
-    await this.goToPath('/contact-us');
-    await this.page.type('#email', '1 Station Road, Newtown, Countyshire AB1 2CD');
-});
-
-Given('that the user enters a non-government email address into the email field of the contact us form', async function () {
-    await this.goToPath('/contact-us');
-    await this.page.type('#email', 'bill@microsoft.com');
-});
-
-Then('their data is sent to Zendesk', async function () {
+Then("their data is sent to Zendesk", async function () {
     // We can't really test this unless we just run a unit test or something
     return true;
 });
 
 async function fillInUserInfoFields(page: Page) {
-    await page.type('#email', 'tessa.ting@gov.uk');
-    await page.type('#name', 'Tessa Ting');
-    await page.type('#role', 'Chief Unicorn Tester');
-    await page.type('#service-name', 'Unicorn Testing');
-    await page.type('#organisation-name', 'Department of Sorcery');
+    await page.type("#email", "tessa.ting@gov.uk");
+    await page.type("#name", "Tessa Ting");
+    await page.type("#role", "Chief Unicorn Tester");
+    await page.type("#service-name", "Unicorn Testing");
+    await page.type("#organisation-name", "Department of Sorcery");
 }

--- a/features/support/steps/contact-us-steps.ts
+++ b/features/support/steps/contact-us-steps.ts
@@ -10,7 +10,7 @@ Given('that the users enter alphanumeric characters into all of the fields in th
 Given('that the users enter alphanumeric characters into all of the fields in the contact us form except the name field', async function () {
     await this.goToPath('/contact-us');
     await this.page.type('#role', 'Chief Unicorn Tester');
-    await this.page.type('#email', 'tessa.ting@foo-bar.gov.uk');
+    await this.page.type('#email', 'tessa.ting@gov.uk');
     await this.page.type('#service-name', 'Unicorn Testing');
     await this.page.type('#organisation-name', 'Department of Sorcery');
     await this.page.type('#how-can-we-help', "We'd like fairies to be able to sign up to get their unicorns tested.");
@@ -35,7 +35,7 @@ Given('that the users enter alphanumeric characters into all of the fields in th
 
 Given('that the users enter alphanumeric characters into all of the fields in the contact us form except the organisation-name field', async function () {
     await this.goToPath('/contact-us');
-    await this.page.type('#email', 'tessa.ting@foo-bar.gov.uk');
+    await this.page.type('#email', 'tessa.ting@gov.uk');
     await this.page.type('#name', 'Tessa Ting');
     await this.page.type('#role', 'Chief Unicorn Tester');
     await this.page.type('#service-name', 'Unicorn Testing');
@@ -44,7 +44,7 @@ Given('that the users enter alphanumeric characters into all of the fields in th
 
 Given('that the users enter alphanumeric characters into all of the fields in the contact us form except the service-name field', async function () {
     await this.goToPath('/contact-us');
-    await this.page.type('#email', 'tessa.ting@foo-bar.gov.uk');
+    await this.page.type('#email', 'tessa.ting@gov.uk');
     await this.page.type('#name', 'Tessa Ting');
     await this.page.type('#role', 'Chief Unicorn Tester');
     await this.page.type('#organisation-name', 'Department of Sorcery');
@@ -72,7 +72,7 @@ Then('their data is sent to Zendesk', async function () {
 });
 
 async function fillInUserInfoFields(page: Page) {
-    await page.type('#email', 'tessa.ting@foo-bar.gov.uk');
+    await page.type('#email', 'tessa.ting@gov.uk');
     await page.type('#name', 'Tessa Ting');
     await page.type('#role', 'Chief Unicorn Tester');
     await page.type('#service-name', 'Unicorn Testing');

--- a/features/support/steps/decide-contact-links-steps.ts
+++ b/features/support/steps/decide-contact-links-steps.ts
@@ -1,18 +1,18 @@
-import { Then } from '@cucumber/cucumber';
-import { checkUrl, getLink } from './shared-functions';
+import {Then} from "@cucumber/cucumber";
+import {checkUrl, getLink} from "./shared-functions";
 
-Then('the Slack link will contain the correct URL', async function () {
-    let slackLinkText: string = 'Slack channel'
-    let slackLinkUrl: string = 'https://ukgovernmentdigital.slack.com/archives/C02AQUJ6WTC'
+Then("the Slack link will contain the correct URL", async function () {
+    const slackLinkText = "Slack channel";
+    const slackLinkUrl = "https://ukgovernmentdigital.slack.com/archives/C02AQUJ6WTC";
 
-    let link = await getLink(this.page, slackLinkText);
+    const link = await getLink(this.page, slackLinkText);
     await checkUrl(this.page, link, slackLinkUrl);
 });
 
-Then('the support form link on the main decide page will contain the correct URL', async function () {
-    let contactUsText: string = 'support form'
-    let contactUsUrl: string = '/contact-us'
+Then("the support form link on the main decide page will contain the correct URL", async function () {
+    const contactUsText = "support form";
+    const contactUsUrl = "/contact-us";
 
-    let link = await getLink(this.page, contactUsText);
+    const link = await getLink(this.page, contactUsText);
     await checkUrl(this.page, link, contactUsUrl);
 });

--- a/features/support/steps/documentation-steps.ts
+++ b/features/support/steps/documentation-steps.ts
@@ -1,25 +1,34 @@
-import { Then } from '@cucumber/cucumber';
-import { strict as assert } from 'assert';
-import { Page } from 'puppeteer';
+import {Then} from "@cucumber/cucumber";
+import {strict as assert} from "assert";
+import {Page} from "puppeteer";
 
-Then('the left-hand navigation menu is displayed', async function () {
-    let technicalDocumentation = await this.page.$x(`//nav[@class="side-navigation"]/ul[contains(@class, "govuk-list")]//a[@href="/documentation"][text()="Technical documentation"]`);
-    assertElementFound(technicalDocumentation, 'Technical documentation');
-    let userJourneyMaps = await this.page.$x(`//nav[@class="side-navigation"]/ul[contains(@class, "govuk-list")]//a[@href="/documentation/user-journeys"][text()="User journey maps"]`);
-    assertElementFound(userJourneyMaps, 'User journey maps');
-    let designRecommendations = await this.page.$x(`//nav[@class="side-navigation"]/ul[contains(@class, "govuk-list")]//a[@href="/documentation/design-recommendations"][contains(text(), "Design recommendations")]`);
-    assertElementFound(designRecommendations, 'Design recommendations');
+Then("the left-hand navigation menu is displayed", async function () {
+    const technicalDocumentation = await this.page.$x(
+        `//nav[@class="side-navigation"]/ul[contains(@class, "govuk-list")]//a[@href="/documentation"][text()="Technical documentation"]`
+    );
+    assertElementFound(technicalDocumentation, "Technical documentation");
+    const userJourneyMaps = await this.page.$x(
+        `//nav[@class="side-navigation"]/ul[contains(@class, "govuk-list")]//a[@href="/documentation/user-journeys"][text()="User journey maps"]`
+    );
+    assertElementFound(userJourneyMaps, "User journey maps");
+    const designRecommendations = await this.page.$x(
+        `//nav[@class="side-navigation"]/ul[contains(@class, "govuk-list")]//a[@href="/documentation/design-recommendations"][contains(text(), "Design recommendations")]`
+    );
+    assertElementFound(designRecommendations, "Design recommendations");
 });
 
 function assertElementFound(element: any, description: string): void {
     assert.equal(element.length, 1, `Couldn't find ${description} link in menu`);
 }
 
-Then('the {string} link is the active item', async function (item: string) {
+Then("the {string} link is the active item", async function (item: string) {
     await assertElementIsActiveItem(this.page, item);
 });
 
 async function assertElementIsActiveItem(page: Page, item: string) {
-    let element = await page.$x(`//nav[@class="side-navigation"]/ul[contains(@class, "govuk-list")]//li[contains(@class, "side-navigation__item--active")]//a[contains(text(), "${item}")]`);
+    const element = await page.$x(
+        `//nav[@class="side-navigation"]/ul[contains(@class, "govuk-list")]//li[contains(@class, "side-navigation__item--active")]//a[contains(text(), "${item}")]`
+    );
+
     assert.equal(element.length, 1, `${item} was not the active element`);
 }

--- a/features/support/steps/mailing-list-steps.ts
+++ b/features/support/steps/mailing-list-steps.ts
@@ -1,47 +1,59 @@
-import { Given } from '@cucumber/cucumber';
+import {Given} from "@cucumber/cucumber";
 
-Given('that the users enter alphanumeric characters into all of the fields in the mailing list form', async function () {
-    await this.goToPath('/mailing-list');
-    await this.page.type('#personalName', 'Tessa Ting');
-    await this.page.type('#organisationName', 'Department of Sorcery');
-    await this.page.type('#contactEmail', 'tessa.ting@gov.uk');
-    await this.page.type('#serviceName', 'Unicorn Testing');
+Given("that the users enter alphanumeric characters into all of the fields in the mailing list form", async function () {
+    await this.goToPath("/mailing-list");
+    await this.page.type("#personalName", "Tessa Ting");
+    await this.page.type("#organisationName", "Department of Sorcery");
+    await this.page.type("#contactEmail", "tessa.ting@gov.uk");
+    await this.page.type("#serviceName", "Unicorn Testing");
 });
 
-Given('that the users enter alphanumeric characters into all of the fields in the mailing list form except the Name field', async function () {
-    await this.goToPath('/mailing-list');
-    await this.page.type('#organisationName', 'Department of Sorcery');
-    await this.page.type('#contactEmail', 'tessa.ting@gov.uk');
-    await this.page.type('#serviceName', 'Unicorn Testing');
+Given(
+    "that the users enter alphanumeric characters into all of the fields in the mailing list form except the Name field",
+    async function () {
+        await this.goToPath("/mailing-list");
+        await this.page.type("#organisationName", "Department of Sorcery");
+        await this.page.type("#contactEmail", "tessa.ting@gov.uk");
+        await this.page.type("#serviceName", "Unicorn Testing");
+    }
+);
+
+Given(
+    "that the users enter alphanumeric characters into all of the fields in the mailing list form except the Organisation name field",
+    async function () {
+        await this.goToPath("/mailing-list");
+        await this.page.type("#personalName", "Tessa Ting");
+        await this.page.type("#contactEmail", "tessa.ting@gov.uk");
+        await this.page.type("#serviceName", "Unicorn Testing");
+    }
+);
+
+Given(
+    "that the users enter alphanumeric characters into all of the fields in the mailing list form except the Contact email field",
+    async function () {
+        await this.goToPath("/mailing-list");
+        await this.page.type("#personalName", "Tessa Ting");
+        await this.page.type("#organisationName", "Department of Sorcery");
+        await this.page.type("#serviceName", "Unicorn Testing");
+    }
+);
+
+Given(
+    "that the users enter alphanumeric characters into all of the fields in the mailing list form except the Service name field",
+    async function () {
+        await this.goToPath("/mailing-list");
+        await this.page.type("#personalName", "Tessa Ting");
+        await this.page.type("#organisationName", "Department of Sorcery");
+        await this.page.type("#contactEmail", "tessa.ting@gov.uk");
+    }
+);
+
+Given("that the user enters an invalid email address into the email field of join our mailing list form", async function () {
+    await this.goToPath("/mailing-list");
+    await this.page.type("#contactEmail", "1 Station Road, Newtown, Countyshire AB1 2CD");
 });
 
-Given('that the users enter alphanumeric characters into all of the fields in the mailing list form except the Organisation name field', async function () {
-    await this.goToPath('/mailing-list');
-    await this.page.type('#personalName', 'Tessa Ting');
-    await this.page.type('#contactEmail', 'tessa.ting@gov.uk');
-    await this.page.type('#serviceName', 'Unicorn Testing');
-});
-
-Given('that the users enter alphanumeric characters into all of the fields in the mailing list form except the Contact email field', async function () {
-    await this.goToPath('/mailing-list');
-    await this.page.type('#personalName', 'Tessa Ting');
-    await this.page.type('#organisationName', 'Department of Sorcery');
-    await this.page.type('#serviceName', 'Unicorn Testing');
-});
-
-Given('that the users enter alphanumeric characters into all of the fields in the mailing list form except the Service name field', async function () {
-    await this.goToPath('/mailing-list');
-    await this.page.type('#personalName', 'Tessa Ting');
-    await this.page.type('#organisationName', 'Department of Sorcery');
-    await this.page.type('#contactEmail', 'tessa.ting@gov.uk');
-});
-
-Given('that the user enters an invalid email address into the email field of join our mailing list form', async function () {
-    await this.goToPath('/mailing-list');
-    await this.page.type('#contactEmail', '1 Station Road, Newtown, Countyshire AB1 2CD');
-});
-
-Given('that the user enters a non-government email address into the email field of join our mailing list form', async function () {
-    await this.goToPath('/mailing-list');
-    await this.page.type('#contactEmail', 'bill@microsoft.com');
+Given("that the user enters a non-government email address into the email field of join our mailing list form", async function () {
+    await this.goToPath("/mailing-list");
+    await this.page.type("#contactEmail", "bill@microsoft.com");
 });

--- a/features/support/steps/mailing-list-steps.ts
+++ b/features/support/steps/mailing-list-steps.ts
@@ -4,21 +4,21 @@ Given('that the users enter alphanumeric characters into all of the fields in th
     await this.goToPath('/mailing-list');
     await this.page.type('#personalName', 'Tessa Ting');
     await this.page.type('#organisationName', 'Department of Sorcery');
-    await this.page.type('#contactEmail', 'tessa.ting@foo-bar.gov.uk');
+    await this.page.type('#contactEmail', 'tessa.ting@gov.uk');
     await this.page.type('#serviceName', 'Unicorn Testing');
 });
 
 Given('that the users enter alphanumeric characters into all of the fields in the mailing list form except the Name field', async function () {
     await this.goToPath('/mailing-list');
     await this.page.type('#organisationName', 'Department of Sorcery');
-    await this.page.type('#contactEmail', 'tessa.ting@foo-bar.gov.uk');
+    await this.page.type('#contactEmail', 'tessa.ting@gov.uk');
     await this.page.type('#serviceName', 'Unicorn Testing');
 });
 
 Given('that the users enter alphanumeric characters into all of the fields in the mailing list form except the Organisation name field', async function () {
     await this.goToPath('/mailing-list');
     await this.page.type('#personalName', 'Tessa Ting');
-    await this.page.type('#contactEmail', 'tessa.ting@foo-bar.gov.uk');
+    await this.page.type('#contactEmail', 'tessa.ting@gov.uk');
     await this.page.type('#serviceName', 'Unicorn Testing');
 });
 
@@ -33,7 +33,7 @@ Given('that the users enter alphanumeric characters into all of the fields in th
     await this.goToPath('/mailing-list');
     await this.page.type('#personalName', 'Tessa Ting');
     await this.page.type('#organisationName', 'Department of Sorcery');
-    await this.page.type('#contactEmail', 'tessa.ting@foo-bar.gov.uk');
+    await this.page.type('#contactEmail', 'tessa.ting@gov.uk');
 });
 
 Given('that the user enters an invalid email address into the email field of join our mailing list form', async function () {

--- a/features/support/steps/register-steps.ts
+++ b/features/support/steps/register-steps.ts
@@ -5,7 +5,7 @@ Given('that the users enter alphanumeric characters into all of the fields', asy
     await this.goToPath('/register');
     await this.page.type('#name', 'Tessa Ting');
     await this.page.type('#organisation-name', 'Department of Sorcery');
-    await this.page.type('#email', 'tessa.ting@foo-bar.gov.uk');
+    await this.page.type('#email', 'tessa.ting@gov.uk');
     await this.page.type('#service-name', 'Unicorn Testing');
     await selectMailingListOption(this.page, "yes");
 
@@ -14,7 +14,7 @@ Given('that the users enter alphanumeric characters into all of the fields', asy
 Given('that the users enter alphanumeric characters into all of the fields in the register form except the Name field', async function () {
     await this.goToPath('/register');
     await this.page.type('#organisation-name', 'Department of Sorcery');
-    await this.page.type('#email', 'tessa.ting@foo-bar.gov.uk');
+    await this.page.type('#email', 'tessa.ting@gov.uk');
     await this.page.type('#service-name', 'Unicorn Testing');
     await selectMailingListOption(this.page, "yes");
 });
@@ -22,7 +22,7 @@ Given('that the users enter alphanumeric characters into all of the fields in th
 Given('that the users enter alphanumeric characters into all of the fields in the register form except the Organisation name field', async function () {
     await this.goToPath('/register');
     await this.page.type('#name', 'Tessa Ting');
-    await this.page.type('#email', 'tessa.ting@foo-bar.gov.uk');
+    await this.page.type('#email', 'tessa.ting@gov.uk');
     await this.page.type('#service-name', 'Unicorn Testing');
     await selectMailingListOption(this.page, "yes");
 });
@@ -57,7 +57,7 @@ Given('that the users enter alphanumeric characters into all of the fields in th
     await this.goToPath('/register');
     await this.page.type('#name', 'Tessa Ting');
     await this.page.type('#organisation-name', 'Department of Sorcery');
-    await this.page.type('#email', 'tessa.ting@foo-bar.gov.uk');
+    await this.page.type('#email', 'tessa.ting@gov.uk');
     await this.page.type('#service-name', 'Unicorn Testing');
 });
 
@@ -65,7 +65,7 @@ Given('that the users enter alphanumeric characters into all of the fields in th
     await this.goToPath('/register');
     await this.page.type('#name', 'Tessa Ting');
     await this.page.type('#organisation-name', 'Department of Sorcery');
-    await this.page.type('#email', 'tessa.ting@foo-bar.gov.uk');
+    await this.page.type('#email', 'tessa.ting@gov.uk');
     await this.page.type('#service-name', 'Unicorn Testing');
     await selectMailingListOption(this.page, "no");
 });

--- a/features/support/steps/register-steps.ts
+++ b/features/support/steps/register-steps.ts
@@ -1,4 +1,5 @@
 import { Given } from '@cucumber/cucumber';
+import {Page} from "puppeteer";
 
 Given('that the users enter alphanumeric characters into all of the fields', async function () {
     await this.goToPath('/register');
@@ -6,7 +7,7 @@ Given('that the users enter alphanumeric characters into all of the fields', asy
     await this.page.type('#organisation-name', 'Department of Sorcery');
     await this.page.type('#email', 'tessa.ting@foo-bar.gov.uk');
     await this.page.type('#service-name', 'Unicorn Testing');
-    await this.page.click('#mailing-list-yes');
+    await selectMailingListOption(this.page, "yes");
 
 });
 
@@ -15,7 +16,7 @@ Given('that the users enter alphanumeric characters into all of the fields in th
     await this.page.type('#organisation-name', 'Department of Sorcery');
     await this.page.type('#email', 'tessa.ting@foo-bar.gov.uk');
     await this.page.type('#service-name', 'Unicorn Testing');
-    await this.page.click('#mailing-list-yes');
+    await selectMailingListOption(this.page, "yes");
 });
 
 Given('that the users enter alphanumeric characters into all of the fields in the register form except the Organisation name field', async function () {
@@ -23,7 +24,7 @@ Given('that the users enter alphanumeric characters into all of the fields in th
     await this.page.type('#name', 'Tessa Ting');
     await this.page.type('#email', 'tessa.ting@foo-bar.gov.uk');
     await this.page.type('#service-name', 'Unicorn Testing');
-    await this.page.click('#mailing-list-yes');
+    await selectMailingListOption(this.page, "yes");
 });
 
 Given('that the users enter alphanumeric characters into all of the fields in the register form except the Contact email field', async function () {
@@ -31,15 +32,15 @@ Given('that the users enter alphanumeric characters into all of the fields in th
     await this.page.type('#name', 'Tessa Ting');
     await this.page.type('#organisation-name', 'Department of Sorcery');
     await this.page.type('#service-name', 'Unicorn Testing');
-    await this.page.click('#mailing-list-yes');
+    await selectMailingListOption(this.page, "yes");
 });
 
 Given('that the users enter alphanumeric characters into all of the fields in the register form except the Service name field', async function () {
     await this.goToPath('/register');
     await this.page.type('#name', 'Tessa Ting');
     await this.page.type('#organisation-name', 'Department of Sorcery');
-    await this.page.type('#email', 'tessa.ting@foo-bar.gov.uk');
-    await this.page.click('#mailing-list-yes');
+    await this.page.type('#email', 'tessa.ting@gov.uk');
+    await selectMailingListOption(this.page, "yes");
 });
 
 Given('that the user enters an invalid email address into the email field', async function () {
@@ -66,5 +67,10 @@ Given('that the users enter alphanumeric characters into all of the fields in th
     await this.page.type('#organisation-name', 'Department of Sorcery');
     await this.page.type('#email', 'tessa.ting@foo-bar.gov.uk');
     await this.page.type('#service-name', 'Unicorn Testing');
-    await this.page.click('#mailing-list-no');
+    await selectMailingListOption(this.page, "no");
 });
+
+async function selectMailingListOption(page: Page, value: string) {
+    const radio = await page.$x(`//div[@id="mailing-list-options"]//input[@value="${value}"]`);
+    await radio[0].click();
+}

--- a/features/support/steps/register-steps.ts
+++ b/features/support/steps/register-steps.ts
@@ -1,74 +1,88 @@
-import { Given } from '@cucumber/cucumber';
+import {Given} from "@cucumber/cucumber";
 import {Page} from "puppeteer";
 
-Given('that the users enter alphanumeric characters into all of the fields', async function () {
-    await this.goToPath('/register');
-    await this.page.type('#name', 'Tessa Ting');
-    await this.page.type('#organisation-name', 'Department of Sorcery');
-    await this.page.type('#email', 'tessa.ting@gov.uk');
-    await this.page.type('#service-name', 'Unicorn Testing');
-    await selectMailingListOption(this.page, "yes");
-
-});
-
-Given('that the users enter alphanumeric characters into all of the fields in the register form except the Name field', async function () {
-    await this.goToPath('/register');
-    await this.page.type('#organisation-name', 'Department of Sorcery');
-    await this.page.type('#email', 'tessa.ting@gov.uk');
-    await this.page.type('#service-name', 'Unicorn Testing');
+Given("that the users enter alphanumeric characters into all of the fields", async function () {
+    await this.goToPath("/register");
+    await this.page.type("#name", "Tessa Ting");
+    await this.page.type("#organisation-name", "Department of Sorcery");
+    await this.page.type("#email", "tessa.ting@gov.uk");
+    await this.page.type("#service-name", "Unicorn Testing");
     await selectMailingListOption(this.page, "yes");
 });
 
-Given('that the users enter alphanumeric characters into all of the fields in the register form except the Organisation name field', async function () {
-    await this.goToPath('/register');
-    await this.page.type('#name', 'Tessa Ting');
-    await this.page.type('#email', 'tessa.ting@gov.uk');
-    await this.page.type('#service-name', 'Unicorn Testing');
+Given("that the users enter alphanumeric characters into all of the fields in the register form except the Name field", async function () {
+    await this.goToPath("/register");
+    await this.page.type("#organisation-name", "Department of Sorcery");
+    await this.page.type("#email", "tessa.ting@gov.uk");
+    await this.page.type("#service-name", "Unicorn Testing");
     await selectMailingListOption(this.page, "yes");
 });
 
-Given('that the users enter alphanumeric characters into all of the fields in the register form except the Contact email field', async function () {
-    await this.goToPath('/register');
-    await this.page.type('#name', 'Tessa Ting');
-    await this.page.type('#organisation-name', 'Department of Sorcery');
-    await this.page.type('#service-name', 'Unicorn Testing');
-    await selectMailingListOption(this.page, "yes");
+Given(
+    "that the users enter alphanumeric characters into all of the fields in the register form except the Organisation name field",
+    async function () {
+        await this.goToPath("/register");
+        await this.page.type("#name", "Tessa Ting");
+        await this.page.type("#email", "tessa.ting@gov.uk");
+        await this.page.type("#service-name", "Unicorn Testing");
+        await selectMailingListOption(this.page, "yes");
+    }
+);
+
+Given(
+    "that the users enter alphanumeric characters into all of the fields in the register form except the Contact email field",
+    async function () {
+        await this.goToPath("/register");
+        await this.page.type("#name", "Tessa Ting");
+        await this.page.type("#organisation-name", "Department of Sorcery");
+        await this.page.type("#service-name", "Unicorn Testing");
+        await selectMailingListOption(this.page, "yes");
+    }
+);
+
+Given(
+    "that the users enter alphanumeric characters into all of the fields in the register form except the Service name field",
+    async function () {
+        await this.goToPath("/register");
+        await this.page.type("#name", "Tessa Ting");
+        await this.page.type("#organisation-name", "Department of Sorcery");
+        await this.page.type("#email", "tessa.ting@gov.uk");
+        await selectMailingListOption(this.page, "yes");
+    }
+);
+
+Given("that the user enters an invalid email address into the email field", async function () {
+    await this.goToPath("/register");
+    await this.page.type("#email", "1 Station Road, Newtown, Countyshire AB1 2CD");
 });
 
-Given('that the users enter alphanumeric characters into all of the fields in the register form except the Service name field', async function () {
-    await this.goToPath('/register');
-    await this.page.type('#name', 'Tessa Ting');
-    await this.page.type('#organisation-name', 'Department of Sorcery');
-    await this.page.type('#email', 'tessa.ting@gov.uk');
-    await selectMailingListOption(this.page, "yes");
+Given("that the user enters a non-government email address into the email field", async function () {
+    await this.goToPath("/register");
+    await this.page.type("#email", "bill@microsoft.com");
 });
 
-Given('that the user enters an invalid email address into the email field', async function () {
-    await this.goToPath('/register');
-    await this.page.type('#email', '1 Station Road, Newtown, Countyshire AB1 2CD');
-});
+Given(
+    "that the users enter alphanumeric characters into all of the fields in the register form except the mailing-list radio",
+    async function () {
+        await this.goToPath("/register");
+        await this.page.type("#name", "Tessa Ting");
+        await this.page.type("#organisation-name", "Department of Sorcery");
+        await this.page.type("#email", "tessa.ting@gov.uk");
+        await this.page.type("#service-name", "Unicorn Testing");
+    }
+);
 
-Given('that the user enters a non-government email address into the email field', async function () {
-    await this.goToPath('/register');
-    await this.page.type('#email', 'bill@microsoft.com');
-});
-
-Given('that the users enter alphanumeric characters into all of the fields in the register form except the mailing-list radio', async function () {
-    await this.goToPath('/register');
-    await this.page.type('#name', 'Tessa Ting');
-    await this.page.type('#organisation-name', 'Department of Sorcery');
-    await this.page.type('#email', 'tessa.ting@gov.uk');
-    await this.page.type('#service-name', 'Unicorn Testing');
-});
-
-Given('that the users enter alphanumeric characters into all of the fields in the register form and select no for the mailing list', async function () {
-    await this.goToPath('/register');
-    await this.page.type('#name', 'Tessa Ting');
-    await this.page.type('#organisation-name', 'Department of Sorcery');
-    await this.page.type('#email', 'tessa.ting@gov.uk');
-    await this.page.type('#service-name', 'Unicorn Testing');
-    await selectMailingListOption(this.page, "no");
-});
+Given(
+    "that the users enter alphanumeric characters into all of the fields in the register form and select no for the mailing list",
+    async function () {
+        await this.goToPath("/register");
+        await this.page.type("#name", "Tessa Ting");
+        await this.page.type("#organisation-name", "Department of Sorcery");
+        await this.page.type("#email", "tessa.ting@gov.uk");
+        await this.page.type("#service-name", "Unicorn Testing");
+        await selectMailingListOption(this.page, "no");
+    }
+);
 
 async function selectMailingListOption(page: Page, value: string) {
     const radio = await page.$x(`//div[@id="mailing-list-options"]//input[@value="${value}"]`);

--- a/features/support/steps/request-private-beta-steps.ts
+++ b/features/support/steps/request-private-beta-steps.ts
@@ -1,47 +1,62 @@
-import { Given } from '@cucumber/cucumber';
+import {Given} from "@cucumber/cucumber";
 
-Given('that the users enter alphanumeric characters into all of the fields in the request access to private beta form', async function () {
-    await this.goToPath('/decide/private-beta/request-form');
-    await this.page.type('#email', 'tessa.ting@gov.uk');
-    await this.page.type('#name', 'Tessa Ting');
-    await this.page.type('#service-name', 'Unicorn Testing');
-    await this.page.type('#department-name', 'Department of Sorcery');
+Given("that the users enter alphanumeric characters into all of the fields in the request access to private beta form", async function () {
+    await this.goToPath("/decide/private-beta/request-form");
+    await this.page.type("#email", "tessa.ting@gov.uk");
+    await this.page.type("#name", "Tessa Ting");
+    await this.page.type("#service-name", "Unicorn Testing");
+    await this.page.type("#department-name", "Department of Sorcery");
 });
 
-Given('that the users enter alphanumeric characters into all of the fields in the request access to private beta form except the name field', async function () {
-    await this.goToPath('/decide/private-beta/request-form');
-    await this.page.type('#email', 'tessa.ting@gov.uk');
-    await this.page.type('#service-name', 'Unicorn Testing');
-    await this.page.type('#department-name', 'Department of Sorcery');
+Given(
+    "that the users enter alphanumeric characters into all of the fields in the request access to private beta form except the name field",
+    async function () {
+        await this.goToPath("/decide/private-beta/request-form");
+        await this.page.type("#email", "tessa.ting@gov.uk");
+        await this.page.type("#service-name", "Unicorn Testing");
+        await this.page.type("#department-name", "Department of Sorcery");
+    }
+);
+
+Given(
+    "that the users enter alphanumeric characters into all of the fields in the request access to private beta form except the email field",
+    async function () {
+        await this.goToPath("/decide/private-beta/request-form");
+        await this.page.type("#name", "Tessa Ting");
+        await this.page.type("#service-name", "Unicorn Testing");
+        await this.page.type("#department-name", "Department of Sorcery");
+    }
+);
+
+Given(
+    "that the users enter alphanumeric characters into all of the fields in the request access to private beta form except the department-name field",
+    async function () {
+        await this.goToPath("/decide/private-beta/request-form");
+        await this.page.type("#email", "tessa.ting@gov.uk");
+        await this.page.type("#name", "Tessa Ting");
+        await this.page.type("#service-name", "Unicorn Testing");
+    }
+);
+
+Given(
+    "that the users enter alphanumeric characters into all of the fields in the request access to private beta form except the service-name field",
+    async function () {
+        await this.goToPath("/decide/private-beta/request-form");
+        await this.page.type("#email", "tessa.ting@gov.uk");
+        await this.page.type("#name", "Tessa Ting");
+        await this.page.type("#department-name", "Department of Sorcery");
+    }
+);
+
+Given("that the user enters an invalid email address into the email field of the request access to private beta form", async function () {
+    await this.goToPath("/decide/private-beta/request-form");
+    await this.page.type("#email", "1 Station Road, Newtown, Countyshire AB1 2CD");
 });
 
-Given('that the users enter alphanumeric characters into all of the fields in the request access to private beta form except the email field', async function () {
-    await this.goToPath('/decide/private-beta/request-form');
-    await this.page.type('#name', 'Tessa Ting');
-    await this.page.type('#service-name', 'Unicorn Testing');
-    await this.page.type('#department-name', 'Department of Sorcery');
-});
-
-Given('that the users enter alphanumeric characters into all of the fields in the request access to private beta form except the department-name field', async function () {
-    await this.goToPath('/decide/private-beta/request-form');
-    await this.page.type('#email', 'tessa.ting@gov.uk');
-    await this.page.type('#name', 'Tessa Ting');
-    await this.page.type('#service-name', 'Unicorn Testing');
-});
-
-Given('that the users enter alphanumeric characters into all of the fields in the request access to private beta form except the service-name field', async function () {
-    await this.goToPath('/decide/private-beta/request-form');
-    await this.page.type('#email', 'tessa.ting@gov.uk');
-    await this.page.type('#name', 'Tessa Ting');
-    await this.page.type('#department-name', 'Department of Sorcery');
-});
-
-Given('that the user enters an invalid email address into the email field of the request access to private beta form', async function () {
-    await this.goToPath('/decide/private-beta/request-form');
-    await this.page.type('#email', '1 Station Road, Newtown, Countyshire AB1 2CD');
-});
-
-Given('that the user enters a non-government email address into the email field of the request access to private beta form', async function () {
-    await this.goToPath('/decide/private-beta/request-form');
-    await this.page.type('#email', 'bill@microsoft.com');
-});
+Given(
+    "that the user enters a non-government email address into the email field of the request access to private beta form",
+    async function () {
+        await this.goToPath("/decide/private-beta/request-form");
+        await this.page.type("#email", "bill@microsoft.com");
+    }
+);

--- a/features/support/steps/request-private-beta-steps.ts
+++ b/features/support/steps/request-private-beta-steps.ts
@@ -2,7 +2,7 @@ import { Given } from '@cucumber/cucumber';
 
 Given('that the users enter alphanumeric characters into all of the fields in the request access to private beta form', async function () {
     await this.goToPath('/decide/private-beta/request-form');
-    await this.page.type('#email', 'tessa.ting@foo-bar.gov.uk');
+    await this.page.type('#email', 'tessa.ting@gov.uk');
     await this.page.type('#name', 'Tessa Ting');
     await this.page.type('#service-name', 'Unicorn Testing');
     await this.page.type('#department-name', 'Department of Sorcery');
@@ -10,7 +10,7 @@ Given('that the users enter alphanumeric characters into all of the fields in th
 
 Given('that the users enter alphanumeric characters into all of the fields in the request access to private beta form except the name field', async function () {
     await this.goToPath('/decide/private-beta/request-form');
-    await this.page.type('#email', 'tessa.ting@foo-bar.gov.uk');
+    await this.page.type('#email', 'tessa.ting@gov.uk');
     await this.page.type('#service-name', 'Unicorn Testing');
     await this.page.type('#department-name', 'Department of Sorcery');
 });
@@ -24,14 +24,14 @@ Given('that the users enter alphanumeric characters into all of the fields in th
 
 Given('that the users enter alphanumeric characters into all of the fields in the request access to private beta form except the department-name field', async function () {
     await this.goToPath('/decide/private-beta/request-form');
-    await this.page.type('#email', 'tessa.ting@foo-bar.gov.uk');
+    await this.page.type('#email', 'tessa.ting@gov.uk');
     await this.page.type('#name', 'Tessa Ting');
     await this.page.type('#service-name', 'Unicorn Testing');
 });
 
 Given('that the users enter alphanumeric characters into all of the fields in the request access to private beta form except the service-name field', async function () {
     await this.goToPath('/decide/private-beta/request-form');
-    await this.page.type('#email', 'tessa.ting@foo-bar.gov.uk');
+    await this.page.type('#email', 'tessa.ting@gov.uk');
     await this.page.type('#name', 'Tessa Ting');
     await this.page.type('#department-name', 'Department of Sorcery');
 });

--- a/features/support/steps/shared-functions.ts
+++ b/features/support/steps/shared-functions.ts
@@ -1,12 +1,15 @@
-import { strict as assert } from 'assert';
-import { ElementHandle, Page } from 'puppeteer';
+import {strict as assert} from "assert";
+import {ElementHandle, Page} from "puppeteer";
 
 export async function getLink(page: Page, linkText: string): Promise<any> {
-    let links = await page.$x(`//a[text()="${linkText}"]`);
+    const links = await page.$x(`//a[text()="${linkText}"]`);
     assert.equal(links.length, 1, `More than one link matched ${linkText}`);
-    return links
+    return links;
 }
 
 export async function checkUrl(page: Page, links: ElementHandle[], expectedUrl: string): Promise<void> {
-    assert.equal(await page.evaluate((anchor: { getAttribute: (arg0: string) => any; }) => anchor.getAttribute('href'), links[0]), expectedUrl);
+    assert.equal(
+        await page.evaluate((anchor: {getAttribute: (arg0: string) => any}) => anchor.getAttribute("href"), links[0]),
+        expectedUrl
+    );
 }

--- a/features/support/steps/shared-steps.ts
+++ b/features/support/steps/shared-steps.ts
@@ -1,82 +1,70 @@
-import { Given, Then, When } from '@cucumber/cucumber';
-import { strict as assert } from 'assert';
-import { Page } from 'puppeteer';
-import { checkUrl, getLink } from './shared-functions';
+import {Given, Then, When} from "@cucumber/cucumber";
+import {strict as assert} from "assert";
+import {Page} from "puppeteer";
+import {checkUrl, getLink} from "./shared-functions";
 
-Given('that the user is on the {string} page', async function (route: string) {
+Given("that the user is on the {string} page", async function (route: string) {
     await this.goToPath(route);
 });
 
-When('they click on the {string} link', async function (text: string) {
-    let links = await this.page.$x(`//a[contains(text(), "${text}")]`);
-    await Promise.all([
-        this.page.waitForNavigation({ timeout: 10000 }),
-        links[0].click()
-    ]);
+When("they click on the {string} link", async function (text: string) {
+    const links = await this.page.$x(`//a[contains(text(), "${text}")]`);
+    await Promise.all([this.page.waitForNavigation({timeout: 10000}), links[0].click()]);
 });
 
-When('they click on the {string} button-link', async function (text: string) {
-    let links = await this.page.$x(`//a[contains(text(), "${text}")][@class="govuk-button"]`);
-    await Promise.all([
-        this.page.waitForNavigation({ timeout: 10000 }),
-        links[0].click()
-    ]);
+When("they click on the {string} button-link", async function (text: string) {
+    const links = await this.page.$x(`//a[contains(text(), "${text}")][@class="govuk-button"]`);
+    await Promise.all([this.page.waitForNavigation({timeout: 10000}), links[0].click()]);
 });
 
-When('they click the {string} button', async function (name: string) {
-    let button = await this.page.$x(`//button[contains(text(), '${name}')]`);
-    await Promise.all([
-        this.page.waitForNavigation({timeout: 10000}),
-        button[0].click()
-    ]);
+When("they click the {string} button", async function (name: string) {
+    const button = await this.page.$x(`//button[contains(text(), '${name}')]`);
+    await Promise.all([this.page.waitForNavigation({timeout: 10000}), button[0].click()]);
 });
 
-When('they select the Submit button', async function () {
-    let button = await this.page.$x(`//button[contains(text(), 'Submit')]`);
-    await Promise.all([
-        this.page.waitForNavigation({timeout: 10000}),
-        button[0].click()
-    ]);
+When("they select the Submit button", async function () {
+    const button = await this.page.$x(`//button[contains(text(), 'Submit')]`);
+    await Promise.all([this.page.waitForNavigation({timeout: 10000}), button[0].click()]);
 });
 
-Then('they should be directed to the following page: {string}', async function (path) {
+Then("they should be directed to the following page: {string}", async function (path) {
     const expectedUrl = new URL(path, this.host);
     assert.equal(this.page.url(), expectedUrl.href);
 });
 
-Then('they should be directed to the following URL: {string}', async function (url) {
+Then("they should be directed to the following URL: {string}", async function (url) {
     assert.equal(this.page.url(), url);
 });
 
-Then('they should be directed to a page with the title {string}', async function (title: string) {
-    let actualTitle = await this.page.title();
+Then("they should be directed to a page with the title {string}", async function (title: string) {
+    const actualTitle = await this.page.title();
     assert.equal(actualTitle, title, `Page title was ${actualTitle}`);
 });
 
-Then('their data is saved in the spreadsheet', async function () {
+Then("their data is saved in the spreadsheet", async function () {
     // we can't check the sheet but if we're on the right page and can find some content then that's good enough
 });
 
-Then('the error message {string} must be displayed for the {string} field', async function (errorMessage, field) {
+Then("the error message {string} must be displayed for the {string} field", async function (errorMessage, field) {
     await checkErrorMessageDisplayedAboveElement(this.page, errorMessage, field);
 });
 
-Then('the error message {string} must be displayed for the {string} radios', async function (errorMessage, field) {
+Then("the error message {string} must be displayed for the {string} radios", async function (errorMessage, field) {
     await checkErrorMessageDisplayedAboveElement(this.page, errorMessage, field);
 });
 
-Then('they should see the text {string}', async function (text) {
-    let bodyText: string = await this.page.$eval('body', (element: any) => element.textContent)
-    assert.equal(bodyText.includes(text), true, `Body text does not contain "${text}"`)
+Then("they should see the text {string}", async function (text) {
+    const bodyText: string = await this.page.$eval("body", (element: any) => element.textContent);
+    assert.equal(bodyText.includes(text), true, `Body text does not contain "${text}"`);
 });
 
-Then('the {string} link will point to the following URL: {string}', async function (linkText, expectedUrl) {
-    let link = await getLink(this.page, linkText);
+Then("the {string} link will point to the following URL: {string}", async function (linkText, expectedUrl) {
+    const link = await getLink(this.page, linkText);
     await checkUrl(this.page, link, expectedUrl);
 });
 
-Then('the {string} link will point to the following page: {string}', async function (linkText, expectedPage) {
-    let link = await getLink(this.page, linkText);
+Then("the {string} link will point to the following page: {string}", async function (linkText, expectedPage) {
+    const link = await getLink(this.page, linkText);
     await checkUrl(this.page, link, expectedPage);
 });
 
@@ -91,5 +79,9 @@ async function checkErrorMessageDisplayedAboveElement(page: Page, errorMessage: 
     assert.notEqual(messageAboveElement.length, 0, `Expected to find the message "${errorMessage}" above the ${field} field.`);
 
     const actualMessageAboveSummary = await page.evaluate((el: {textContent: any}) => el.textContent, messageAboveElement[0]);
-    assert.equal(actualMessageAboveSummary.trim(), `Error: ${errorMessage}`, `Expected the message above the ${field} field to be "${errorMessage}"`);
+    assert.equal(
+        actualMessageAboveSummary.trim(),
+        `Error: ${errorMessage}`,
+        `Expected the message above the ${field} field to be "${errorMessage}"`
+    );
 }

--- a/features/support/steps/shared-steps.ts
+++ b/features/support/steps/shared-steps.ts
@@ -62,7 +62,7 @@ Then('the error message {string} must be displayed for the {string} field', asyn
 });
 
 Then('the error message {string} must be displayed for the {string} radios', async function (errorMessage, field) {
-    await checkErrorMessageDisplayedAboveElement(this.page, errorMessage, field, true);
+    await checkErrorMessageDisplayedAboveElement(this.page, errorMessage, field);
 });
 
 Then('they should see the text {string}', async function (text) {
@@ -80,14 +80,14 @@ Then('the {string} link will point to the following page: {string}', async funct
     await checkUrl(this.page, link, expectedPage);
 });
 
-async function checkErrorMessageDisplayedAboveElement(page: Page, errorMessage: string, field: string, radios = false) {
+async function checkErrorMessageDisplayedAboveElement(page: Page, errorMessage: string, field: string) {
     const errorLink = await page.$x(`//div[@class="govuk-error-summary"]//a[@href="#${field}"]`);
     assert.notEqual(errorLink.length, 0, `Expected to find the message "${errorMessage}" in the error summary.`);
 
     const actualMessageInSummary = await page.evaluate((el: {textContent: any}) => el.textContent, errorLink[0]);
     assert.equal(actualMessageInSummary, errorMessage, `Expected text of the link to be "${errorMessage}"`);
 
-    const messageAboveElement = await page.$x(`//p[@class="govuk-error-message"][@id="${field}${radios ? "-option" : ""}-error"]`);
+    const messageAboveElement = await page.$x(`//p[@class="govuk-error-message"][@id="${field}-error"]`);
     assert.notEqual(messageAboveElement.length, 0, `Expected to find the message "${errorMessage}" above the ${field} field.`);
 
     const actualMessageAboveSummary = await page.evaluate((el: {textContent: any}) => el.textContent, messageAboveElement[0]);

--- a/features/support/steps/support-steps.ts
+++ b/features/support/steps/support-steps.ts
@@ -1,13 +1,10 @@
-import { When } from '@cucumber/cucumber';
+import {When} from "@cucumber/cucumber";
 
-When('they select the {string} button', async function (id) {
-    await Promise.all([
-        this.page.waitForNavigation(),
-        this.page.click(`#${id}`)
-    ])
+When("they select the {string} button", async function (id) {
+    await Promise.all([this.page.waitForNavigation(), this.page.click(`#${id}`)]);
 });
 
-When('the user selects the {string} radio button', async function (labelText) {
-    let el = await this.page.$x(`//label[contains(text(), "${labelText}")]`);
+When("the user selects the {string} radio button", async function (labelText) {
+    const el = await this.page.$x(`//label[contains(text(), "${labelText}")]`);
     await el[0].click();
 });

--- a/features/support/steps/user-journeys-steps.ts
+++ b/features/support/steps/user-journeys-steps.ts
@@ -1,11 +1,14 @@
-import { Given, Then } from '@cucumber/cucumber';
-import { strict as assert } from 'assert';
+import {Given, Then} from "@cucumber/cucumber";
+import {strict as assert} from "assert";
 
-Given('the user wants to contact the service', async function () {
+Given("the user wants to contact the service", async function () {
     // just here for the story to read better
 });
 
-Then('they would be able to send an email to the service if they selected the {string} link', async function (text: string) {
-    let links = await this.page.$x(`//a[text()="${text}")]`);
-    assert.equal(await this.page.evaluate((anchor: { getAttribute: (arg0: string) => any; }) => anchor.getAttribute('href'), links[0]), `mailto:${text}`);
+Then("they would be able to send an email to the service if they selected the {string} link", async function (text: string) {
+    const links = await this.page.$x(`//a[text()="${text}")]`);
+    assert.equal(
+        await this.page.evaluate((anchor: {getAttribute: (arg0: string) => any}) => anchor.getAttribute("href"), links[0]),
+        `mailto:${text}`
+    );
 });

--- a/features/support/test-setup.ts
+++ b/features/support/test-setup.ts
@@ -1,9 +1,9 @@
-import { After, AfterAll, Before, BeforeAll } from '@cucumber/cucumber';
-import { IWorldOptions } from '@cucumber/cucumber/lib/support_code_library_builder/world';
-import { Browser } from 'puppeteer';
+import {After, AfterAll, Before, BeforeAll} from "@cucumber/cucumber";
+import {IWorldOptions} from "@cucumber/cucumber/lib/support_code_library_builder/world";
+import {Browser} from "puppeteer";
 
-const puppeteer = require('puppeteer');
-const { setWorldConstructor, World } = require('@cucumber/cucumber');
+const puppeteer = require("puppeteer");
+const {setWorldConstructor, World} = require("@cucumber/cucumber");
 
 let browser: Browser;
 
@@ -18,21 +18,25 @@ class TestContext extends World {
 }
 
 BeforeAll(async function () {
-    console.log(`Running tests against ${process.env.HOST || 'local'}`)
-    browser = await puppeteer.launch({ headless: true });
-})
+    console.log(`Running tests against ${process.env.HOST || "local"}`);
+    browser = await puppeteer.launch({headless: !process.env.SHOW_BROWSER});
+});
 
 Before(async function () {
-    this.host = process.env.HOST as string || 'http://localhost:3000';
+    this.host = (process.env.HOST as string) || "http://localhost:3000";
     this.page = await browser.newPage();
-})
+});
 
 After(async function () {
-    await this.page.close();
-})
+    if (!process.env.SHOW_BROWSER) {
+        await this.page.close();
+    }
+});
 
 AfterAll(async function () {
-    await browser.close();
-})
+    if (!process.env.SHOW_BROWSER) {
+        await browser.close();
+    }
+});
 
 setWorldConstructor(TestContext);

--- a/src/config/configureViews.ts
+++ b/src/config/configureViews.ts
@@ -2,7 +2,7 @@ import {Express} from "express-serve-static-core";
 import {configure, render} from "nunjucks";
 import * as path from "path";
 
-export default function (app: Express, viewPath = path.join(__dirname, "../../src/views")) {
+export default function (app: Express, viewPath: string = path.join(__dirname, "../../src/views")) {
     const govukViews = require.resolve("govuk-frontend").match(/.*govuk-frontend\//)?.[0];
 
     if (!govukViews) {

--- a/src/controllers/support.ts
+++ b/src/controllers/support.ts
@@ -11,7 +11,7 @@ export const submitForm = function (req: Request, res: Response) {
     const values = new Map<string, string>(Object.entries(req.body));
     const errorMessages = (req.app.get("validation") as Validation).validate(values, requiredFields);
 
-    if (errorMessages.has("support")) {
+    if (errorMessages.size > 0) {
         res.render("support.njk", {errorMessages: errorMessages});
         return;
     }

--- a/src/lib/validation/email-validator/index.ts
+++ b/src/lib/validation/email-validator/index.ts
@@ -1,13 +1,13 @@
-'use strict'
+"use strict";
 
 // npm dependencies
-const rfc822Validator = require('rfc822-validate')
+const rfc822Validator = require("rfc822-validate");
 
 module.exports = (email: string) => {
     if (!rfc822Validator(email)) {
-        return false
+        return false;
     } else {
-        let domain = email.split('@')[1]
-        return !(domain && domain.indexOf('.') === -1)
+        const domain = email.split("@")[1];
+        return !(domain && domain.indexOf(".") === -1);
     }
-}
+};

--- a/src/lib/validation/validation.spec.ts
+++ b/src/lib/validation/validation.spec.ts
@@ -1,56 +1,71 @@
-import {assert} from 'chai'
+import {assert} from "chai";
 
-import Validation from './index'
+import Validation from "./index";
 
 let validator: Validation;
 
-before( function() {
+before(function () {
     validator = new Validation();
-})
+});
 
-describe('Validation tests', function () {
-
-    let requiredFields = new Map<string, string>();
-    requiredFields.set("email", "Enter your government email address");
-    requiredFields.set("name", "Enter your name");
-    requiredFields.set("service-name", "Enter the name of your service");
-    requiredFields.set("department-name", "Enter your department");
+describe("Validation tests", function () {
+    const requiredFields = new Map<string, string>([
+        ["email", "Enter your government email address"],
+        ["name", "Enter your name"],
+        ["service-name", "Enter the name of your service"],
+        ["department-name", "Enter your department"]
+    ]);
 
     it("doesn't return any errors for a valid form", function () {
         assert.equal(validator.validate(completedValidForm(), requiredFields).size, 0);
     });
 
-    it('returns 4 errors if the form is empty', function () {
-        assert.equal(validator.validate(new Map<string, string>(), requiredFields).size, 4, 'expected to see 4 errors');
+    it("returns 4 errors if the form is empty", function () {
+        assert.equal(validator.validate(new Map<string, string>(), requiredFields).size, 4, "expected to see 4 errors");
     });
 
-    it('does not accept foo@bar.com as a valid email address because it is not a government address', function () {
-        let emailError = validator.validate(new Map<string, string>(Object.entries({email: "foo@bar.com"})), requiredFields).get("email")
-        assert.equal(emailError,
+    it("does not accept foo@bar.com as a valid email address because it is not a government address", function () {
+        const emailError = validator.validate(new Map<string, string>(Object.entries({email: "foo@bar.com"})), requiredFields).get("email");
+        assert.equal(
+            emailError,
             "Enter a government email address",
-            "There are three possible error conditions for the email field - empty, invalid, not a government email.");
+            "There are three possible error conditions for the email field - empty, invalid, not a government email."
+        );
     });
 
-    it('does not accept foo@bar as a valid email address because the domain is incomplete', function () {
-        let emailError = validator.validate(new Map<string, string>(Object.entries({email: "foo@bar"})), requiredFields).get("email")
-        assert.equal(emailError,
+    it("does not accept foo@bar as a valid email address because the domain is incomplete", function () {
+        const emailError = validator.validate(new Map<string, string>(Object.entries({email: "foo@bar"})), requiredFields).get("email");
+        assert.equal(
+            emailError,
             "Enter an email address in the correct format, like name@gov.uk",
-            "There are three possible error conditions for the email field - empty, invalid, not a government email.");
+            "There are three possible error conditions for the email field - empty, invalid, not a government email."
+        );
     });
 
-    it('it accepts bl.uk as a valid email domain', async function() {
-        let form = completedValidForm();
-        form.set('email', "bookworm@bl.uk")
+    it("does not accept foo@foo.gov.uk as a valid email address because the domain is not valid", function () {
+        const emailError = validator.validate(new Map<string, string>(Object.entries({email: "foo@bar"})), requiredFields).get("email");
+        assert.equal(
+            emailError,
+            "Enter an email address in the correct format, like name@gov.uk",
+            "There are three possible error conditions for the email field - empty, invalid, not a government email."
+        );
+    });
+
+    it("it accepts bl.uk as a valid email domain", async function () {
+        const form = completedValidForm();
+        form.set("email", "bookworm@bl.uk");
         assert.equal(validator.validate(form, requiredFields).size, 0, "bl.uk is one of the domains in valid-email-domains.txt");
-    })
-})
+    });
+});
 
 function completedValidForm(): Map<string, string> {
-    return new Map<string, string>(Object.entries({
-        email: "testing@one23.gov.uk",
-        name: "Tessa Ting",
-        "service-name": "Testing Service",
-        "department-name": "Department of form testing",
-        // optional fields not included
-    }));
+    return new Map<string, string>(
+        Object.entries({
+            email: "testing@gov.uk",
+            name: "Tessa Ting",
+            "service-name": "Testing Service",
+            "department-name": "Department of form testing"
+            // optional fields not included
+        })
+    );
 }

--- a/src/views/macros/form.njk
+++ b/src/views/macros/form.njk
@@ -68,12 +68,12 @@
   }) }}
 {% endmacro %}
 
-{% macro radiosInput(label, id, hint, items) %}
+{% macro radiosInput(label, name, hint, items) %}
   {{ govukRadios({
-    name: id,
-    idPrefix: id + "-option",
+    name: name,
+    idPrefix: name,
     attributes: {
-      id: id
+      id: name + "-options"
     },
     fieldset: {
       legend: {
@@ -83,10 +83,10 @@
     hint: {
       text: hint
     } if hint,
-    value: values.get(id) if values,
+    value: values.get(name) if values,
     items: items,
     errorMessage: {
-      text: errorMessages.get(id)
-    } if errorMessages and errorMessages.has(id)
+      text: errorMessages.get(name)
+    } if errorMessages and errorMessages.has(name)
   }) }}
 {% endmacro %}

--- a/src/views/register.njk
+++ b/src/views/register.njk
@@ -15,18 +15,10 @@
   {{ form.textInput("Organisation name", "organisation-name", "govuk-!-width-two-thirds") }}
   {{ form.emailInput("Contact email") }}
   {{ form.textInput("Service name", "service-name", "govuk-!-width-full") }}
-  {{ form.radiosInput("Would you like to join our mailing list?", id = "mailing-list",
+  {{ form.radiosInput("Would you like to join our mailing list?", name = "mailing-list",
     hint = "You’ll get occasional email updates about our work and invitations to our cross-government show and tells.",
     items = [
-      {
-        text: "Yes",
-        value: "yes",
-        id: "mailing-list-yes"
-      },
-      {
-        text: "No",
-        value: "no",
-        id: "mailing-list-no"
-      }
+      {text: "Yes", value: "yes"},
+      {text: "No", value: "no"}
     ]) }}
 {% endblock %}

--- a/src/views/support.njk
+++ b/src/views/support.njk
@@ -12,7 +12,7 @@
 {% endblock %}
 
 {% block formInputs %}
-  {{ form.radiosInput("What do you need help with?", id = "support",
+  {{ form.radiosInput("What do you need help with?", name = "support",
     items = [
       {
         text: "I work in a government service team and we want to start using GOV.UK Sign In",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "sourceMap": true,                        /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "./dist",                       /* Redirect output structure to the directory. */
-    "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
     "removeComments": true,                   /* Do not emit comments to output. */
@@ -46,7 +46,7 @@
     // "resolveJsonModule": true,             /* Allows importing modules with a .json extension */
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+     "rootDirs": ["src", "features"],         /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */


### PR DESCRIPTION
-  Point the error link to the first radio button when no option selected

-  Format steps 
    Apply prettier/eslint formatting

- Fix bug in email validator
  Check that the whole part after the @ sign in the email matches one of the domains to make sure domains that end in a valid domain but prefixed with an arbitrary string are rejected. This means that domains such as `foo.gov.uk` are now rejected where they were previously accepted.