### PR TITLE
BAU add allowed domain

### DIFF
--- a/valid-email-domains.txt
+++ b/valid-email-domains.txt
@@ -784,6 +784,7 @@ communities.gov.uk
 localdigital.gov.uk
 justice.gsi.gov.uk
 justice.gov.uk
+digital.justice.gov.uk
 mirfieldtowncouncil.gov.uk
 capel-pc.gov.uk
 mole-valley.gov.uk


### PR DESCRIPTION
add `digital.justice.gov.uk` to list of allowed domains.

eventually change implementation to work like SSE.