### PR TITLE
Updated the accessibility statement due to new status page

### DIFF
--- a/src/views/accessibility.njk
+++ b/src/views/accessibility.njk
@@ -60,13 +60,19 @@
   </p>
 
   <p class="govuk-body">
-    DAC assessed the GOV.UK One Login website against the Web Content Accessibility Guidelines WCAG 2.1.
+    DAC assessed the GOV.UK One Login website against the Web Content Accessibility Guidelines (WCAG) 2.1.
   </p>
 
-  <h2 class="govuk-heading-m">What we’re doing to improve accessibility</h2>
+  <p class="govuk-body">
+    Since then we have continued to carry out manual testing against WCAG 2.1.
+  </p>
+
+  <h2 class="govuk-heading-m">
+    What we’re doing to improve accessibility
+  </h2>
 
   <p class="govuk-body">
-    Following recommendations from the testing carried out by the Digital Accessibility Centre (DAC), we have fixed all outstanding A and AA issues.
+    Following recommendations from the testing carried out by the DAC in October 2021, we fixed outstanding A and AA issues on the GOV.UK One Login site.
   </p>
 
   <p class="govuk-body">
@@ -75,6 +81,13 @@
     <li>making link text more descriptive</li>
     <li>marking fields in our registration form as optional</li>
   </ul>
+  </p>
+
+   <p class="govuk-body">
+    We are continuing to look at fixing the accessibility issues on the 
+    <a href="https://status.account.gov.uk/" class="govuk-link">GOV.UK One Login's status page</a> which 
+    was added in May 2023. You can <a href="#non-compliances-section" class="govuk-link">
+    find out more about the non-compliances on the GOV.UK One Login status page</a>.
   </p>
 
   <h2 class="govuk-heading-m">
@@ -129,6 +142,55 @@
     The Government Digital Service is committed to making its websites accessible,
     in accordance with the Public Sector Bodies (Websites and Mobile Applications)
     (No. 2) Accessibility Regulations 2018.
+    <br><br>
+    This website is partially compliant with the WCAG version 
+    2.1 AA standard, due to the non-compliances listed below.
+  </p>
+
+  <h3 class="govuk-heading-m" id="non-compliances-section">
+    Non-compliance with the accessibility regulations
+  </h3>
+  
+  <p class="govuk-body">
+    The following content on <a href="https://status.account.gov.uk/" class="govuk-link">GOV.UK One Login's status page</a> 
+    is not compliant with the WCAG version 2.1 AA standard. 
+  </p>
+
+  <h4 class="govuk-heading-s">
+    Level A failures
+  </h4>
+
+  <p class="govuk-body">
+    <ul class="govuk-list govuk-list--bullet">
+      <li>Infographics across the pages do not have text alternatives - users who are unable to see the visual presentation of this information will not have access to it (WCAG success criterion 1.1.1)</li>
+      <li>‘Subscribe to updates’ link does not contain link text that is accessible by assistive technologies (WCAG success criterion 1.3.1)</li>
+      <li>‘Subscribe to updates’ form fields do not have clear labels (WCAG success criterion 1.3.1)</li>
+      <li>Text presentation uses incorrect semantics - for example headers and other elements of the visual structure are not accessible to people who cannot see this visual presentation (WCAG success criterion 1.3.1)</li>
+      <li>Infographics use colour as the only way of conveying information - information on when outages occurred is not accessible to users with many forms of colour blindness (WCAG success criterion 1.4.1)</li>
+      <li>Use of colour is the only way to differentiate between text and a link - users with many forms of colour blindness cannot recognise when a link is available (WCAG success criterion 1.4.1)</li>
+      <li>Some content is only revealed when hovering over it - this information cannot be accessed by people using mobile phones or alternative keyboards (WCAG success criterion 2.1.1)</li>
+      <li>Some links are implemented in a way that is not consistent with HTML nesting rules - links may not work or may behave in unexpected ways across different assistive technologies (WCAG success criterion 4.1.1)</li>
+      <li>‘Subscribe to updates’ forms do not indicate to users that they are expandable or collapsible (WCAG success criterion 4.1.2)</li>
+    </ul>
+  </p>
+
+  <h4 class="govuk-heading-s">
+    Level AA failures
+  </h4>
+
+  <p class="govuk-body">
+    <ul class="govuk-list govuk-list--bullet">
+      <li>Multiple text elements use poor contrast with their backgrounds making some text elements not perceivable to people with moderately low vision (WCAG success criterion 1.4.3)</li>
+      <li>Text size cannot be increased to 200% without negative effects such as text overlapping or text being cut off (WCAG success criterion 1.4.4)</li>
+      <li>Content cannot be presented without loss of information when using browser zoom at 400% (WCAG success criterion 1.4.10)</li>
+      <li>Information is lost when text spacing is increased (WCAG success criterion 1.4.12)</li>
+      <li>Elements within the infographics reveal content on hover which cannot be switched off - users cannot see the original infographics due to hover content being continuously re-triggered and covering the underlying content (WCAG success criterion 1.4.13)</li>
+      <li>‘Subscribe to updates’ forms, when submitted with incorrect data, do not inform screen reader users of the error message when it becomes available (WCAG success criterion 4.1.3)</li>
+    </ul>
+  </p>
+
+  <p class="govuk-body">
+    Together with the supplier of the GOV.UK One Login status page, we intend to make this service fully accessible. We are continuously improving and reviewing the service.
   </p>
 
   <h2 class="govuk-heading-m">
@@ -136,6 +198,6 @@
   </h2>
 
   <p class="govuk-body">
-    This statement was prepared on 21 July 2021. It was last reviewed on 12 November 2021.
+    This statement was prepared on 16 May 2023. It was last reviewed on 16 May 2023.
   </p>
 {% endblock %}


### PR DESCRIPTION
Recently, we introduce the GOV.UK One Login status page (https://status.account.gov.uk/) to communicate incidents to external stakeholders. There are several accessibility issues on the status page, so of which can only be fixed by the 3rd party provider of some of the functionality of the status page (statuspage.io) 

This means, the accessibility statement has to be updated to list the non-compliance of the GOV.UK One Login status page. 

Content review was done here: https://docs.google.com/document/d/1BR3VPvjXgKC5ipmWIVV537ekR1RFlVKnV2fsO6_PRso/edit# 

