### PR TITLE
Removed bullet points of accessibility issues that have now been fixed

### DIFF
--- a/src/views/accessibility.njk
+++ b/src/views/accessibility.njk
@@ -162,15 +162,8 @@
 
   <p class="govuk-body">
     <ul class="govuk-list govuk-list--bullet">
-      <li>Infographics across the pages do not have text alternatives - users who are unable to see the visual presentation of this information will not have access to it (WCAG success criterion 1.1.1)</li>
-      <li>‘Subscribe to updates’ link does not contain link text that is accessible by assistive technologies (WCAG success criterion 1.3.1)</li>
-      <li>‘Subscribe to updates’ form fields do not have clear labels (WCAG success criterion 1.3.1)</li>
       <li>Text presentation uses incorrect semantics - for example headers and other elements of the visual structure are not accessible to people who cannot see this visual presentation (WCAG success criterion 1.3.1)</li>
-      <li>Infographics use colour as the only way of conveying information - information on when outages occurred is not accessible to users with many forms of colour blindness (WCAG success criterion 1.4.1)</li>
-      <li>Use of colour is the only way to differentiate between text and a link - users with many forms of colour blindness cannot recognise when a link is available (WCAG success criterion 1.4.1)</li>
-      <li>Some content is only revealed when hovering over it - this information cannot be accessed by people using mobile phones or alternative keyboards (WCAG success criterion 2.1.1)</li>
       <li>Some links are implemented in a way that is not consistent with HTML nesting rules - links may not work or may behave in unexpected ways across different assistive technologies (WCAG success criterion 4.1.1)</li>
-      <li>‘Subscribe to updates’ forms do not indicate to users that they are expandable or collapsible (WCAG success criterion 4.1.2)</li>
     </ul>
   </p>
 
@@ -183,8 +176,6 @@
       <li>Multiple text elements use poor contrast with their backgrounds making some text elements not perceivable to people with moderately low vision (WCAG success criterion 1.4.3)</li>
       <li>Text size cannot be increased to 200% without negative effects such as text overlapping or text being cut off (WCAG success criterion 1.4.4)</li>
       <li>Content cannot be presented without loss of information when using browser zoom at 400% (WCAG success criterion 1.4.10)</li>
-      <li>Information is lost when text spacing is increased (WCAG success criterion 1.4.12)</li>
-      <li>Elements within the infographics reveal content on hover which cannot be switched off - users cannot see the original infographics due to hover content being continuously re-triggered and covering the underlying content (WCAG success criterion 1.4.13)</li>
       <li>‘Subscribe to updates’ forms, when submitted with incorrect data, do not inform screen reader users of the error message when it becomes available (WCAG success criterion 4.1.3)</li>
     </ul>
   </p>


### PR DESCRIPTION
Earlier in the year, we found several accessibility issues with the One Login status page. Since then, the majority of these issues have now been fixed. Therefore, we want to update the accessibility statement to take off the bullet points of issues that are now resolved. 

The updated statement (2i'ed by Kim Clayden on 9 June 2023) can be found here: https://docs.google.com/document/d/1u6C4d2MrKemiAoz3-XcKS6XffijO63iHGWgldyfZa9A/edit

