### PR TITLE
SSE-2789 - Add digital.mod.uk and digital.trade.gov.uk domains to accepted government services emails

### DIFF
--- a/resources/allowed-email-domains.txt
+++ b/resources/allowed-email-domains.txt
@@ -1998,3 +1998,5 @@ garthhillcollege.com
 hallcrossacademy.co.uk
 queenelizabeths.derbyshire.sch.uk
 stmartinscranbrook.devon.sch.uk
+digital.mod.uk
+digital.trade.gov.uk


### PR DESCRIPTION
Add digital.mod.uk and digital.trade.gov.uk domains to accepted government services emails